### PR TITLE
Fix version / package.json for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ public/
 web
 package
 .vscode
+examples/*.lock
+*.diff

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "examples",
+  "version": "0.0.0",
+  "description": "Camino Platform JS Library Examples",
+  "license": "BSD-3-Clause",
+  "scripts":{
+    "run-example":"NODE_OPTIONS=--openssl-legacy-provider ts-node"
+  },
+  "devDependencies": {
+    "@c4tplatform/caminojs": "file:../c4tplatform-caminojs-v1.0.0.tgz"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "dependencies": {}
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./typings/",
+    "baseUrl": ".",
+    "module": "commonjs",
+    "target": "ES2015",
+    "lib": ["dom", "es2016"],
+    "declaration": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "declarationMap": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictFunctionTypes": true,
+    "esModuleInterop": true,
+    "typeRoots": ["./typings/**", "./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "examples", "typings"],
+  "typeAcquisition": {
+    "enable": true,
+    "exclude": ["bn.js"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/caminojs",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Camino Platform JS Library",
   "main": "dist/index.js",
   "scripts": {
@@ -10,6 +10,7 @@
     "bundle": "webpack --mode production",
     "lint": "eslint ./ --ext js,ts --fix",
     "prepublish": "yarn build",
+    "examples:prepare": "yarn build && yarn pack",
     "release:prepare": "rm -rf ./dist ./node_modules && yarn install && yarn build && yarn bundle && yarn test && git status",
     "test": "jest",
     "test-watch": "jest --watch",


### PR DESCRIPTION
- Fix version (v1.0.0) in package.json
- Add package.json for examples.

## Examples
- call yarn examples:prepare in root
- head over into examples folder, call yarn
After this you can run examples with ts-node

Note: the examples are using RIPDEM160 hashing which is not part of node's internal openssl by default beginning node version 1.17. You have to set NODE_OPTIONS=--openssl-legacy-provider environment env var before running an example with node versions >= 1.17.
