### PR TITLE
Prepare for different codecIDs / fix avm codecId namings

### DIFF
--- a/src/apis/avm/constants.ts
+++ b/src/apis/avm/constants.ts
@@ -20,11 +20,11 @@ export class AVMConstants {
 
   static NFTXFEROUTPUTID: number = 11
 
-  static NFTXFEROUTPUTID_CODECONE: number = 131073
+  static NFTXFEROUTPUTID_CODECTWO: number = 131073
 
   static NFTMINTOUTPUTID: number = 10
 
-  static NFTMINTOUTPUTID_CODECONE: number = 131072
+  static NFTMINTOUTPUTID_CODECTWO: number = 131072
 
   static SECPINPUTID: number = 5
 
@@ -36,11 +36,11 @@ export class AVMConstants {
 
   static NFTMINTOPID: number = 12
 
-  static NFTMINTOPID_CODECONE: number = 131074
+  static NFTMINTOPID_CODECTWO: number = 131074
 
   static NFTXFEROPID: number = 13
 
-  static NFTXFEROPID_CODECONE: number = 131075
+  static NFTXFEROPID_CODECTWO: number = 131075
 
   static VERTEX: number = 0
 
@@ -72,7 +72,7 @@ export class AVMConstants {
 
   static NFTCREDENTIAL: number = 14
 
-  static NFTCREDENTIAL_CODECONE: number = 131076
+  static NFTCREDENTIAL_CODECTWO: number = 131076
 
   static ASSETIDLEN: number = 32
 

--- a/src/apis/avm/credentials.ts
+++ b/src/apis/avm/credentials.ts
@@ -26,7 +26,7 @@ export const SelectCredentialClass = (
   }
   if (
     credid === AVMConstants.NFTCREDENTIAL ||
-    credid === AVMConstants.NFTCREDENTIAL_CODECONE
+    credid === AVMConstants.NFTCREDENTIAL_CODECTWO
   ) {
     return new NFTCredential(...args)
   }
@@ -89,7 +89,7 @@ export class NFTCredential extends Credential {
   protected _typeID =
     this._codecID === 0
       ? AVMConstants.NFTCREDENTIAL
-      : AVMConstants.NFTCREDENTIAL_CODECONE
+      : AVMConstants.NFTCREDENTIAL_CODECTWO
 
   //serialize and deserialize both are inherited
 
@@ -109,7 +109,7 @@ export class NFTCredential extends Credential {
     this._typeID =
       this._codecID === 0
         ? AVMConstants.NFTCREDENTIAL
-        : AVMConstants.NFTCREDENTIAL_CODECONE
+        : AVMConstants.NFTCREDENTIAL_CODECTWO
   }
 
   getCredentialID(): number {

--- a/src/apis/avm/ops.ts
+++ b/src/apis/avm/ops.ts
@@ -51,12 +51,12 @@ export const SelectOperationClass = (
     return new SECPMintOperation(...args)
   } else if (
     opid === AVMConstants.NFTMINTOPID ||
-    opid === AVMConstants.NFTMINTOPID_CODECONE
+    opid === AVMConstants.NFTMINTOPID_CODECTWO
   ) {
     return new NFTMintOperation(...args)
   } else if (
     opid === AVMConstants.NFTXFEROPID ||
-    opid === AVMConstants.NFTXFEROPID_CODECONE
+    opid === AVMConstants.NFTXFEROPID_CODECTWO
   ) {
     return new NFTTransferOperation(...args)
   }
@@ -455,7 +455,7 @@ export class NFTMintOperation extends Operation {
   protected _typeID =
     this._codecID === 0
       ? AVMConstants.NFTMINTOPID
-      : AVMConstants.NFTMINTOPID_CODECONE
+      : AVMConstants.NFTMINTOPID_CODECTWO
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     const fields: object = super.serialize(encoding)
@@ -521,7 +521,7 @@ export class NFTMintOperation extends Operation {
     this._typeID =
       this._codecID === 0
         ? AVMConstants.NFTMINTOPID
-        : AVMConstants.NFTMINTOPID_CODECONE
+        : AVMConstants.NFTMINTOPID_CODECTWO
   }
 
   /**
@@ -538,7 +538,7 @@ export class NFTMintOperation extends Operation {
     if (this._codecID === 0) {
       return AVMConstants.NFTCREDENTIAL
     } else if (this._codecID === 1) {
-      return AVMConstants.NFTCREDENTIAL_CODECONE
+      return AVMConstants.NFTCREDENTIAL_CODECTWO
     }
   }
 
@@ -674,7 +674,7 @@ export class NFTTransferOperation extends Operation {
   protected _typeID =
     this._codecID === 0
       ? AVMConstants.NFTXFEROPID
-      : AVMConstants.NFTXFEROPID_CODECONE
+      : AVMConstants.NFTXFEROPID_CODECTWO
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     const fields: object = super.serialize(encoding)
@@ -707,7 +707,7 @@ export class NFTTransferOperation extends Operation {
     this._typeID =
       this._codecID === 0
         ? AVMConstants.NFTXFEROPID
-        : AVMConstants.NFTXFEROPID_CODECONE
+        : AVMConstants.NFTXFEROPID_CODECTWO
   }
 
   /**
@@ -724,7 +724,7 @@ export class NFTTransferOperation extends Operation {
     if (this._codecID === 0) {
       return AVMConstants.NFTCREDENTIAL
     } else if (this._codecID === 1) {
-      return AVMConstants.NFTCREDENTIAL_CODECONE
+      return AVMConstants.NFTCREDENTIAL_CODECTWO
     }
   }
 

--- a/src/apis/avm/outputs.ts
+++ b/src/apis/avm/outputs.ts
@@ -38,12 +38,12 @@ export const SelectOutputClass = (outputid: number, ...args: any[]): Output => {
     return new SECPMintOutput(...args)
   } else if (
     outputid === AVMConstants.NFTMINTOUTPUTID ||
-    outputid === AVMConstants.NFTMINTOUTPUTID_CODECONE
+    outputid === AVMConstants.NFTMINTOUTPUTID_CODECTWO
   ) {
     return new NFTMintOutput(...args)
   } else if (
     outputid === AVMConstants.NFTXFEROUTPUTID ||
-    outputid === AVMConstants.NFTXFEROUTPUTID_CODECONE
+    outputid === AVMConstants.NFTXFEROUTPUTID_CODECTWO
   ) {
     return new NFTTransferOutput(...args)
   }
@@ -239,7 +239,7 @@ export class NFTMintOutput extends NFTOutput {
   protected _typeID =
     this._codecID === 0
       ? AVMConstants.NFTMINTOUTPUTID
-      : AVMConstants.NFTMINTOUTPUTID_CODECONE
+      : AVMConstants.NFTMINTOUTPUTID_CODECTWO
 
   //serialize and deserialize both are inherited
 
@@ -259,7 +259,7 @@ export class NFTMintOutput extends NFTOutput {
     this._typeID =
       this._codecID === 0
         ? AVMConstants.NFTMINTOUTPUTID
-        : AVMConstants.NFTMINTOUTPUTID_CODECONE
+        : AVMConstants.NFTMINTOUTPUTID_CODECTWO
   }
 
   /**
@@ -329,7 +329,7 @@ export class NFTTransferOutput extends NFTOutput {
   protected _typeID =
     this._codecID === 0
       ? AVMConstants.NFTXFEROUTPUTID
-      : AVMConstants.NFTXFEROUTPUTID_CODECONE
+      : AVMConstants.NFTXFEROUTPUTID_CODECTWO
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
@@ -375,7 +375,7 @@ export class NFTTransferOutput extends NFTOutput {
     this._typeID =
       this._codecID === 0
         ? AVMConstants.NFTXFEROUTPUTID
-        : AVMConstants.NFTXFEROUTPUTID_CODECONE
+        : AVMConstants.NFTXFEROUTPUTID_CODECTWO
   }
 
   /**

--- a/src/apis/platformvm/addsubnetvalidatortx.ts
+++ b/src/apis/platformvm/addsubnetvalidatortx.ts
@@ -27,7 +27,9 @@ const serialization: Serialization = Serialization.getInstance()
  */
 export class AddSubnetValidatorTx extends BaseTx {
   protected _typeName = "AddSubnetValidatorTx"
-  protected _typeID = PlatformVMConstants.ADDSUBNETVALIDATORTX
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.ADDSUBNETVALIDATORTXS
+  )
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
@@ -66,7 +68,7 @@ export class AddSubnetValidatorTx extends BaseTx {
    * Returns the id of the [[AddSubnetValidatorTx]]
    */
   getTxType(): number {
-    return PlatformVMConstants.ADDSUBNETVALIDATORTX
+    return this._typeID
   }
 
   /**
@@ -217,7 +219,7 @@ export class AddSubnetValidatorTx extends BaseTx {
   }
 
   getCredentialID(): number {
-    return PlatformVMConstants.SECPCREDENTIAL
+    return PlatformVMConstants.Get(PlatformVMConstants.SECPCREDENTIALS)
   }
 
   /**

--- a/src/apis/platformvm/basetx.ts
+++ b/src/apis/platformvm/basetx.ts
@@ -25,7 +25,7 @@ const bintools: BinTools = BinTools.getInstance()
  */
 export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
   protected _typeName = "BaseTx"
-  protected _typeID = PlatformVMConstants.CREATESUBNETTX
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.BASETXS)
 
   deserialize(fields: object, encoding: SerializedEncoding = "hex") {
     super.deserialize(fields, encoding)
@@ -61,7 +61,7 @@ export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
    * Returns the id of the [[BaseTx]]
    */
   getTxType(): number {
-    return PlatformVMConstants.BASETX
+    return this._typeID
   }
 
   /**

--- a/src/apis/platformvm/constants.ts
+++ b/src/apis/platformvm/constants.ts
@@ -6,48 +6,43 @@
 export class PlatformVMConstants {
   static LATESTCODEC: number = 0
 
-  static SECPFXID: number = 0
+  static SECPFXIDS: number[] = [0]
 
-  static SECPXFEROUTPUTID: number = 7
+  static SECPXFEROUTPUTIDS: number[] = [7]
 
-  static SUBNETAUTHID: number = 10
+  static SUBNETAUTHIDS: number[] = [10]
 
-  static SECPOWNEROUTPUTID: number = 11
+  static SECPOWNEROUTPUTIDS: number[] = [11]
 
-  static STAKEABLELOCKOUTID: number = 22
+  static STAKEABLELOCKOUTIDS: number[] = [22]
 
-  static SECPINPUTID: number = 5
+  static SECPINPUTIDS: number[] = [5]
 
-  static STAKEABLELOCKINID: number = 21
+  static STAKEABLELOCKINIDS: number[] = [21]
 
-  static LOCKEDSTAKEABLES: number[] = [
-    PlatformVMConstants.STAKEABLELOCKINID,
-    PlatformVMConstants.STAKEABLELOCKOUTID
-  ]
+  static BASETXS: number[] = [0]
 
-  static BASETX: number = 0
+  static SUBNETAUTHS: number[] = [10]
 
-  static SUBNETAUTH: number = 10
+  static ADDVALIDATORTXS: number[] = [12, 12]
 
-  static ADDVALIDATORTX: number = 12
+  static ADDSUBNETVALIDATORTXS: number[] = [13]
 
-  static ADDSUBNETVALIDATORTX: number = 13
+  static ADDDEPOSITTXS: number[] = [14]
 
-  static ADDDEPOSITTX: number = 14
+  static CREATECHAINTXS: number[] = [15]
 
-  static CREATECHAINTX: number = 15
+  static CREATESUBNETTXS: number[] = [16]
 
-  static CREATESUBNETTX: number = 16
+  static IMPORTTXS: number[] = [17]
 
-  static IMPORTTX: number = 17
+  static EXPORTTXS: number[] = [18]
 
-  static EXPORTTX: number = 18
+  static ADVANCETIMETXS: number[] = [19]
 
-  static ADVANCETIMETX: number = 19
+  static REWARDVALIDATORTXS: number[] = [20]
 
-  static REWARDVALIDATORTX: number = 20
-
-  static SECPCREDENTIAL: number = 9
+  static SECPCREDENTIALS: number[] = [9]
 
   static ASSETIDLEN: number = 32
 
@@ -58,4 +53,20 @@ export class PlatformVMConstants {
   static ASSETNAMELEN: number = 128
 
   static ADDRESSLENGTH: number = 20
+
+  // Get the latest possible version
+  static Get(n: number[]): number {
+    const v =
+      PlatformVMConstants.LATESTCODEC < n.length
+        ? PlatformVMConstants.LATESTCODEC
+        : n.length - 1
+    return n[v as number] | (v << 16)
+  }
+
+  // Check if id matches entries in n[], respecting version of id
+  static Is(id: number, n: number[]): boolean {
+    const v = (id >> 16) as number
+    const res = v < n.length ? n[v as number] : n[n.length - 1]
+    return res === id
+  }
 }

--- a/src/apis/platformvm/createchaintx.ts
+++ b/src/apis/platformvm/createchaintx.ts
@@ -26,7 +26,9 @@ const serialization: Serialization = Serialization.getInstance()
  */
 export class CreateChainTx extends BaseTx {
   protected _typeName = "CreateChainTx"
-  protected _typeID = PlatformVMConstants.CREATECHAINTX
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.CREATECHAINTXS
+  )
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
@@ -66,7 +68,7 @@ export class CreateChainTx extends BaseTx {
    * Returns the id of the [[CreateChainTx]]
    */
   getTxType(): number {
-    return PlatformVMConstants.CREATECHAINTX
+    return this._typeID
   }
 
   /**
@@ -252,7 +254,7 @@ export class CreateChainTx extends BaseTx {
   }
 
   getCredentialID(): number {
-    return PlatformVMConstants.SECPCREDENTIAL
+    return PlatformVMConstants.Get(PlatformVMConstants.SECPCREDENTIALS)
   }
 
   /**

--- a/src/apis/platformvm/createsubnettx.ts
+++ b/src/apis/platformvm/createsubnettx.ts
@@ -13,7 +13,9 @@ import { SubnetOwnerError } from "../../utils/errors"
 
 export class CreateSubnetTx extends BaseTx {
   protected _typeName = "CreateSubnetTx"
-  protected _typeID = PlatformVMConstants.CREATESUBNETTX
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.CREATESUBNETTXS
+  )
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)

--- a/src/apis/platformvm/credentials.ts
+++ b/src/apis/platformvm/credentials.ts
@@ -18,7 +18,7 @@ export const SelectCredentialClass = (
   credid: number,
   ...args: any[]
 ): Credential => {
-  if (credid === PlatformVMConstants.SECPCREDENTIAL) {
+  if (PlatformVMConstants.Is(credid, PlatformVMConstants.SECPCREDENTIALS)) {
     return new SECPCredential(...args)
   }
   /* istanbul ignore next */
@@ -27,7 +27,9 @@ export const SelectCredentialClass = (
 
 export class SECPCredential extends Credential {
   protected _typeName = "SECPCredential"
-  protected _typeID = PlatformVMConstants.SECPCREDENTIAL
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.SECPCREDENTIALS
+  )
 
   //serialize and deserialize both are inherited
 

--- a/src/apis/platformvm/exporttx.ts
+++ b/src/apis/platformvm/exporttx.ts
@@ -25,7 +25,7 @@ const serialization: Serialization = Serialization.getInstance()
  */
 export class ExportTx extends BaseTx {
   protected _typeName = "ExportTx"
-  protected _typeID = PlatformVMConstants.EXPORTTX
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.EXPORTTXS)
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
@@ -66,7 +66,7 @@ export class ExportTx extends BaseTx {
    * Returns the id of the [[ExportTx]]
    */
   getTxType(): number {
-    return PlatformVMConstants.EXPORTTX
+    return PlatformVMConstants.Get(PlatformVMConstants.EXPORTTXS)
   }
 
   /**

--- a/src/apis/platformvm/importtx.ts
+++ b/src/apis/platformvm/importtx.ts
@@ -26,7 +26,7 @@ const serialization: Serialization = Serialization.getInstance()
  */
 export class ImportTx extends BaseTx {
   protected _typeName = "ImportTx"
-  protected _typeID = PlatformVMConstants.IMPORTTX
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.IMPORTTXS)
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)

--- a/src/apis/platformvm/inputs.ts
+++ b/src/apis/platformvm/inputs.ts
@@ -29,9 +29,11 @@ const serialization: Serialization = Serialization.getInstance()
  * @returns An instance of an [[Input]]-extended class.
  */
 export const SelectInputClass = (inputid: number, ...args: any[]): Input => {
-  if (inputid === PlatformVMConstants.SECPINPUTID) {
+  if (PlatformVMConstants.Is(inputid, PlatformVMConstants.SECPINPUTIDS)) {
     return new SECPTransferInput(...args)
-  } else if (inputid === PlatformVMConstants.STAKEABLELOCKINID) {
+  } else if (
+    PlatformVMConstants.Is(inputid, PlatformVMConstants.STAKEABLELOCKINIDS)
+  ) {
     return new StakeableLockIn(...args)
   }
   /* istanbul ignore next */
@@ -112,7 +114,7 @@ export abstract class AmountInput extends StandardAmountInput {
 
 export class SECPTransferInput extends AmountInput {
   protected _typeName = "SECPTransferInput"
-  protected _typeID = PlatformVMConstants.SECPINPUTID
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.SECPINPUTIDS)
 
   //serialize and deserialize both are inherited
 
@@ -123,7 +125,8 @@ export class SECPTransferInput extends AmountInput {
     return this._typeID
   }
 
-  getCredentialID = (): number => PlatformVMConstants.SECPCREDENTIAL
+  getCredentialID = (): number =>
+    PlatformVMConstants.Get(PlatformVMConstants.SECPCREDENTIALS)
 
   create(...args: any[]): this {
     return new SECPTransferInput(...args) as this
@@ -141,7 +144,9 @@ export class SECPTransferInput extends AmountInput {
  */
 export class StakeableLockIn extends AmountInput {
   protected _typeName = "StakeableLockIn"
-  protected _typeID = PlatformVMConstants.STAKEABLELOCKINID
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.STAKEABLELOCKINIDS
+  )
 
   //serialize and deserialize both are inherited
 
@@ -206,7 +211,8 @@ export class StakeableLockIn extends AmountInput {
     return this._typeID
   }
 
-  getCredentialID = (): number => PlatformVMConstants.SECPCREDENTIAL
+  getCredentialID = (): number =>
+    PlatformVMConstants.Get(PlatformVMConstants.SECPCREDENTIALS)
 
   /**
    * Popuates the instance from a {@link https://github.com/feross/buffer|Buffer} representing the [[StakeableLockIn]] and returns the size of the output.

--- a/src/apis/platformvm/outputs.ts
+++ b/src/apis/platformvm/outputs.ts
@@ -27,11 +27,15 @@ const serialization: Serialization = Serialization.getInstance()
  * @returns An instance of an [[Output]]-extended class.
  */
 export const SelectOutputClass = (outputid: number, ...args: any[]): Output => {
-  if (outputid == PlatformVMConstants.SECPXFEROUTPUTID) {
+  if (PlatformVMConstants.Is(outputid, PlatformVMConstants.SECPXFEROUTPUTIDS)) {
     return new SECPTransferOutput(...args)
-  } else if (outputid == PlatformVMConstants.SECPOWNEROUTPUTID) {
+  } else if (
+    PlatformVMConstants.Is(outputid, PlatformVMConstants.SECPOWNEROUTPUTIDS)
+  ) {
     return new SECPOwnerOutput(...args)
-  } else if (outputid == PlatformVMConstants.STAKEABLELOCKOUTID) {
+  } else if (
+    PlatformVMConstants.Is(outputid, PlatformVMConstants.STAKEABLELOCKOUTIDS)
+  ) {
     return new StakeableLockOut(...args)
   }
   throw new OutputIdError(
@@ -112,7 +116,9 @@ export abstract class AmountOutput extends StandardAmountOutput {
  */
 export class SECPTransferOutput extends AmountOutput {
   protected _typeName = "SECPTransferOutput"
-  protected _typeID = PlatformVMConstants.SECPXFEROUTPUTID
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.SECPXFEROUTPUTIDS
+  )
 
   //serialize and deserialize both are inherited
 
@@ -139,7 +145,9 @@ export class SECPTransferOutput extends AmountOutput {
  */
 export class StakeableLockOut extends AmountOutput {
   protected _typeName = "StakeableLockOut"
-  protected _typeID = PlatformVMConstants.STAKEABLELOCKOUTID
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.STAKEABLELOCKOUTIDS
+  )
 
   //serialize and deserialize both are inherited
 
@@ -293,7 +301,9 @@ export class StakeableLockOut extends AmountOutput {
  */
 export class SECPOwnerOutput extends Output {
   protected _typeName = "SECPOwnerOutput"
-  protected _typeID = PlatformVMConstants.SECPOWNEROUTPUTID
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.SECPOWNEROUTPUTIDS
+  )
 
   //serialize and deserialize both are inherited
 

--- a/src/apis/platformvm/subnetauth.ts
+++ b/src/apis/platformvm/subnetauth.ts
@@ -14,7 +14,7 @@ const bintools: BinTools = BinTools.getInstance()
 
 export class SubnetAuth extends Serializable {
   protected _typeName = "SubnetAuth"
-  protected _typeID = PlatformVMConstants.SUBNETAUTH
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.SUBNETAUTHS)
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -31,17 +31,23 @@ const bintools: BinTools = BinTools.getInstance()
  * @returns An instance of an [[BaseTx]]-extended class.
  */
 export const SelectTxClass = (txtype: number, ...args: any[]): BaseTx => {
-  if (txtype === PlatformVMConstants.BASETX) {
+  if (PlatformVMConstants.Is(txtype, PlatformVMConstants.BASETXS)) {
     return new BaseTx(...args)
-  } else if (txtype === PlatformVMConstants.IMPORTTX) {
+  } else if (PlatformVMConstants.Is(txtype, PlatformVMConstants.IMPORTTXS)) {
     return new ImportTx(...args)
-  } else if (txtype === PlatformVMConstants.EXPORTTX) {
+  } else if (PlatformVMConstants.Is(txtype, PlatformVMConstants.EXPORTTXS)) {
     return new ExportTx(...args)
-  } else if (txtype === PlatformVMConstants.ADDDEPOSITTX) {
+  } else if (
+    PlatformVMConstants.Is(txtype, PlatformVMConstants.ADDDEPOSITTXS)
+  ) {
     return new AddDepositTx(...args)
-  } else if (txtype === PlatformVMConstants.ADDVALIDATORTX) {
+  } else if (
+    PlatformVMConstants.Is(txtype, PlatformVMConstants.ADDVALIDATORTXS)
+  ) {
     return new AddValidatorTx(...args)
-  } else if (txtype === PlatformVMConstants.CREATESUBNETTX) {
+  } else if (
+    PlatformVMConstants.Is(txtype, PlatformVMConstants.CREATESUBNETTXS)
+  ) {
     return new CreateSubnetTx(...args)
   }
   /* istanbul ignore next */

--- a/src/apis/platformvm/validationtx.ts
+++ b/src/apis/platformvm/validationtx.ts
@@ -241,7 +241,7 @@ export abstract class WeightedValidatorTx extends ValidatorTx {
  */
 export class AddDepositTx extends WeightedValidatorTx {
   protected _typeName = "AddDepositTx"
-  protected _typeID = PlatformVMConstants.ADDDEPOSITTX
+  protected _typeID = PlatformVMConstants.Get(PlatformVMConstants.ADDDEPOSITTXS)
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
@@ -412,7 +412,9 @@ export class AddDepositTx extends WeightedValidatorTx {
 
 export class AddValidatorTx extends WeightedValidatorTx {
   protected _typeName = "AddValidatorTx"
-  protected _typeID = PlatformVMConstants.ADDVALIDATORTX
+  protected _typeID = PlatformVMConstants.Get(
+    PlatformVMConstants.ADDVALIDATORTXS
+  )
 
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)

--- a/tests/apis/avm/ops.test.ts
+++ b/tests/apis/avm/ops.test.ts
@@ -114,7 +114,7 @@ describe("Operations", (): void => {
       nftMintOperation.setCodecID(codecID_one)
       expect(nftMintOperation.getCodecID()).toBe(codecID_one)
       expect(nftMintOperation.getOperationID()).toBe(
-        AVMConstants.NFTMINTOPID_CODECONE
+        AVMConstants.NFTMINTOPID_CODECTWO
       )
       nftMintOperation.setCodecID(codecID_zero)
       expect(nftMintOperation.getCodecID()).toBe(codecID_zero)
@@ -210,7 +210,7 @@ describe("Operations", (): void => {
       nftTransferOperation.setCodecID(codecID_one)
       expect(nftTransferOperation.getCodecID()).toBe(codecID_one)
       expect(nftTransferOperation.getOperationID()).toBe(
-        AVMConstants.NFTXFEROPID_CODECONE
+        AVMConstants.NFTXFEROPID_CODECTWO
       )
       nftTransferOperation.setCodecID(codecID_zero)
       expect(nftTransferOperation.getCodecID()).toBe(codecID_zero)

--- a/tests/apis/avm/outputs.test.ts
+++ b/tests/apis/avm/outputs.test.ts
@@ -65,7 +65,7 @@ describe("Outputs", (): void => {
       nftMintOutput.setCodecID(codecID_one)
       expect(nftMintOutput.getCodecID()).toBe(codecID_one)
       expect(nftMintOutput.getOutputID()).toBe(
-        AVMConstants.NFTMINTOUTPUTID_CODECONE
+        AVMConstants.NFTMINTOUTPUTID_CODECTWO
       )
       nftMintOutput.setCodecID(codecID_zero)
       expect(nftMintOutput.getCodecID()).toBe(codecID_zero)

--- a/tests/apis/platformvm/addsubnetvalidatortx.test.ts
+++ b/tests/apis/platformvm/addsubnetvalidatortx.test.ts
@@ -26,7 +26,7 @@ describe("AddSubnetValidatorTx", (): void => {
   test("getTypeID", async (): Promise<void> => {
     const addSubnetValidatorTxTypeID: number = addSubnetValidatorTx.getTypeID()
     expect(addSubnetValidatorTxTypeID).toBe(
-      PlatformVMConstants.ADDSUBNETVALIDATORTX
+      PlatformVMConstants.Get(PlatformVMConstants.ADDSUBNETVALIDATORTXS)
     )
   })
 
@@ -79,7 +79,9 @@ describe("AddSubnetValidatorTx", (): void => {
 
     test("getTypeID", async (): Promise<void> => {
       const subnetAuthTypeID: number = sa.getTypeID()
-      expect(subnetAuthTypeID).toBe(PlatformVMConstants.SUBNETAUTH)
+      expect(subnetAuthTypeID).toBe(
+        PlatformVMConstants.Get(PlatformVMConstants.SUBNETAUTHS)
+      )
     })
 
     test("getNumAddressIndices", async (): Promise<void> => {

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -53,6 +53,7 @@ import {
   GetBalanceResponse,
   GetUTXOsResponse
 } from "src/apis/platformvm/interfaces"
+import { PlatformVMConstants } from "src/apis/platformvm"
 
 /**
  * @ignore
@@ -2481,6 +2482,67 @@ describe("PlatformVMAPI", (): void => {
       expect(tx4.toBuffer().toString("hex")).toBe(checkTx)
 
       serialzeit(tx1, "CreateSubnetTx")
+    })
+
+    test("buildAddValidatorTx 4", async (): Promise<void> => {
+      const addrbuff1 = addrs1.map((a) => platformvm.parseAddress(a))
+      const addrbuff2 = addrs2.map((a) => platformvm.parseAddress(a))
+      const addrbuff3 = addrs3.map((a) => platformvm.parseAddress(a))
+      const amount: BN = ONEAVAX.mul(new BN(25))
+
+      const locktime: BN = new BN(54321)
+      const threshold: number = 2
+
+      platformvm.setMinStake(ONEAVAX.mul(new BN(25)), ONEAVAX.mul(new BN(25)))
+
+      var txu: UnsignedTx = await platformvm.buildAddValidatorTx(
+        lset,
+        addrs3,
+        addrs1,
+        addrs2,
+        nodeID,
+        startTime,
+        endTime,
+        amount,
+        addrs3,
+        locktime,
+        threshold,
+        new UTF8Payload("hello world"),
+        UnixNow()
+      )
+      var vtx = txu.getTransaction() as AddValidatorTx
+      expect(
+        PlatformVMConstants.Is(
+          vtx.getTypeID(),
+          PlatformVMConstants.ADDVALIDATORTXS
+        )
+      ).toBeTruthy
+
+      PlatformVMConstants.LATESTCODEC = 1
+
+      txu = await platformvm.buildAddValidatorTx(
+        lset,
+        addrs3,
+        addrs1,
+        addrs2,
+        nodeID,
+        startTime,
+        endTime,
+        amount,
+        addrs3,
+        locktime,
+        threshold,
+        new UTF8Payload("hello world"),
+        UnixNow()
+      )
+      vtx = txu.getTransaction() as AddValidatorTx
+      console.log(vtx.getTypeID())
+      expect(
+        PlatformVMConstants.Is(
+          vtx.getTypeID(),
+          PlatformVMConstants.ADDVALIDATORTXS
+        )
+      ).toBeTruthy
     })
 
     test("buildCreateSubnetTx2", async (): Promise<void> => {

--- a/tests/apis/platformvm/createchaintx.test.ts
+++ b/tests/apis/platformvm/createchaintx.test.ts
@@ -23,7 +23,9 @@ describe("CreateChainTx", (): void => {
 
   test("getTypeID", async (): Promise<void> => {
     const createChainTxTypeID: number = createChainTx.getTypeID()
-    expect(createChainTxTypeID).toBe(PlatformVMConstants.CREATECHAINTX)
+    expect(createChainTxTypeID).toBe(
+      PlatformVMConstants.Get(PlatformVMConstants.CREATECHAINTXS)
+    )
   })
 
   test("toBuffer and fromBuffer", async (): Promise<void> => {
@@ -97,7 +99,9 @@ describe("CreateChainTx", (): void => {
 
     test("getTypeID", async (): Promise<void> => {
       const subnetAuthTypeID: number = sa.getTypeID()
-      expect(subnetAuthTypeID).toBe(PlatformVMConstants.SUBNETAUTH)
+      expect(subnetAuthTypeID).toBe(
+        PlatformVMConstants.Get(PlatformVMConstants.SUBNETAUTHS)
+      )
     })
 
     test("getNumAddressIndices", async (): Promise<void> => {

--- a/tests/apis/platformvm/createsubnettx.test.ts
+++ b/tests/apis/platformvm/createsubnettx.test.ts
@@ -18,7 +18,9 @@ describe("CreateSubnetTx", (): void => {
 
   test("getTypeID", async (): Promise<void> => {
     const createSubnetTxTypeID: number = createSubnetTx.getTypeID()
-    expect(createSubnetTxTypeID).toBe(PlatformVMConstants.CREATESUBNETTX)
+    expect(createSubnetTxTypeID).toBe(
+      PlatformVMConstants.Get(PlatformVMConstants.CREATESUBNETTXS)
+    )
   })
 
   test("toBuffer and fromBuffer", async (): Promise<void> => {
@@ -39,12 +41,16 @@ describe("CreateSubnetTx", (): void => {
 
     test("getTypeID", async (): Promise<void> => {
       const subnetOwnersTypeID: number = subnetOwners.getTypeID()
-      expect(subnetOwnersTypeID).toBe(PlatformVMConstants.SECPOWNEROUTPUTID)
+      expect(subnetOwnersTypeID).toBe(
+        PlatformVMConstants.Get(PlatformVMConstants.SECPOWNEROUTPUTIDS)
+      )
     })
 
     test("getOutputID", async (): Promise<void> => {
       const outputID: number = subnetOwners.getOutputID()
-      expect(outputID).toBe(PlatformVMConstants.SECPOWNEROUTPUTID)
+      expect(outputID).toBe(
+        PlatformVMConstants.Get(PlatformVMConstants.SECPOWNEROUTPUTIDS)
+      )
     })
 
     test("get addresses", async (): Promise<void> => {

--- a/tests/apis/platformvm/inputs.test.ts
+++ b/tests/apis/platformvm/inputs.test.ts
@@ -93,7 +93,9 @@ describe("Inputs", (): void => {
     input = new SECPTransferInput(amount)
     xferinput = new TransferableInput(txid, txidx, asset, input)
     expect(xferinput.getUTXOID()).toBe(u.getUTXOID())
-    expect(input.getInputID()).toBe(PlatformVMConstants.SECPINPUTID)
+    expect(input.getInputID()).toBe(
+      PlatformVMConstants.Get(PlatformVMConstants.SECPINPUTIDS)
+    )
 
     input.addSignatureIdx(0, addrs2[0])
     input.addSignatureIdx(1, addrs2[1])


### PR DESCRIPTION
# Camino TypeId changes
Because of the changes in caminogo:PlatformVM (change Validation / remove Delegation / add new LockedIns / Outs), caminogo will bump the codecid from 0 to 1 to allow external applications to distibuish between avax and camino types.

This PR changes:
- Allow dynamic setting of  LATESTCODEC, which is provided by platformVM:getInformation
- Verify versioned types
- Create new instances of types always using LATESTCODEC

#### Note
Right now platformVM:getInformation oes not provide the CodecVersion, CodecVersion 0 is used by default