### PR TITLE
[Types] Implement CaminoAddValidatorTx and locked.Out

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,15 +27,15 @@ env:
 
 jobs:
   e2e:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out chain4travel/caminojs
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'chain4travel/caminojs'
       - name: Check out ${{ github.event.inputs.caminojsRepo }} ${{ github.event.inputs.caminojsBranch }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.caminojsRepo }}
           ref: ${{ github.event.inputs.caminojsBranch }}
@@ -44,9 +44,9 @@ jobs:
       - name: Install NodeJS dependencies
         run: yarn install --frozen-lockfile
       - name: Setup GoLang Version
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.18
       - name: Setup GOPATH and CAMPATH
         run : |
           mkdir -p $GOPATH/$CAMPATH
@@ -55,19 +55,18 @@ jobs:
       - name: Clone and Build Camino Node
         run : |
           cd $GOPATH/$CAMPATH
-          git clone https://github.com/chain4travel/camino-node
+          git clone https://github.com/chain4travel/camino-node --depth 1 -bv0.3.1-alpha1
           cd camino-node
           ./scripts/build.sh
       - name: Checkout Camino Network Runner
         run : |
           cd $GOPATH/$CAMPATH
-          git clone https://github.com/chain4travel/camino-network-runner
+          git clone https://github.com/chain4travel/camino-network-runner --depth 1 -bv0.2.1-alpha1
       - name: Starting Camino Network Runner
         run: |
           cd $GOPATH/$CAMPATH
           cd camino-network-runner
-          git checkout v0.1.4
-          go run ./examples/local/fivenodenetwork/main.go &
+          CAMINO_NODE_PATH=$GOPATH/$CAMPATH/camino-node/build/camino-node go run ./examples/local/fivenodenetwork/main.go &
       - name: CaminoJS E2E Test
         env:
           CAMINOGO_IP: localhost

--- a/e2e_tests/cchain_nomock.test.ts
+++ b/e2e_tests/cchain_nomock.test.ts
@@ -27,7 +27,7 @@ describe("CChain", (): void => {
       () => keystore.createUser(user, passwd),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "importKey",

--- a/e2e_tests/info_nomock.test.ts
+++ b/e2e_tests/info_nomock.test.ts
@@ -14,7 +14,7 @@ describe("Info", (): void => {
       () => info.getBlockchainID("X"),
       (x) => x,
       Matcher.toBe,
-      () => "qzfF3A11KzpcHkkqznEyQgupQrCNS6WV6fTUTwZpEKqhj1QE7"
+      () => "2huFztbeB4LijVCoLrxP8NwFbRCdtLfUyvx4VXwD5VnVxzxkMX"
     ],
     [
       "getNetworkID",
@@ -35,14 +35,14 @@ describe("Info", (): void => {
       () => info.getNodeID(),
       (x) => x,
       Matcher.toBe,
-      () => "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"
+      () => "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL"
     ],
     [
       "getNodeVersion",
       () => info.getNodeVersion(),
       (x) => x,
       Matcher.toMatch,
-      () => /^camino\/\d*\.\d*\.\d*$/
+      () => /^avalanche\/\d*\.\d*\.\d*$/
     ],
     [
       "isBootstrapped",

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -27,7 +27,7 @@ describe("Keystore", (): void => {
       () => keystore.createUser(username1, password),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "createRepeatedUser",
@@ -62,7 +62,7 @@ describe("Keystore", (): void => {
       () => keystore.importUser(username2, exportedUser.value, password),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "exportImportUser",
@@ -73,7 +73,7 @@ describe("Keystore", (): void => {
         })(),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "listUsers2",
@@ -87,21 +87,21 @@ describe("Keystore", (): void => {
       () => keystore.deleteUser(username1, password),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "deleteUser2",
       () => keystore.deleteUser(username2, password),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "deleteUser3",
       () => keystore.deleteUser(username3, password),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ]
   ]
 

--- a/e2e_tests/pchain_nomock.test.ts
+++ b/e2e_tests/pchain_nomock.test.ts
@@ -25,11 +25,11 @@ describe("PChain", (): void => {
   const whaleAddr: string = "P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
   const key: string =
     "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
-  const nodeID: string = "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"
+  const nodeID: string = "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL"
   const subnetID: string = "2bGsYJorY6X7RhjPBFs3kYjiNEHo4zGrD2eeyZbb43T2KKi7fM"
   const xChainAddr: string = "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
   const avalancheBlockChainID: string =
-    "2VvmkRw4yrz8tPrVnCCbvEK1JxNyujpqhmU6SGonxMpkWBx9UD"
+    "11111111111111111111111111111111LpoYY"
 
   const rewardUTXOTxID: string =
     "2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4"
@@ -40,7 +40,7 @@ describe("PChain", (): void => {
       () => keystore.createUser(user, passwd),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "createaddrB",
@@ -91,21 +91,21 @@ describe("PChain", (): void => {
       () => pchain.getBlockchains(),
       (x) => x[0].id,
       Matcher.toBe,
-      () => "BR28ypgLATNS6PbtHMiJ7NQ61vfpT27Hj8tAcZ1AHsfU5cz88"
+      () => "2LqjNQWTVU7KEkFC5WenqdcwRzsjmJH1erk1xbFQDwt5EHC1Zr"
     ],
     [
       "getBlockchainsX",
       () => pchain.getBlockchains(),
       (x) => x[1].id,
       Matcher.toBe,
-      () => "qzfF3A11KzpcHkkqznEyQgupQrCNS6WV6fTUTwZpEKqhj1QE7"
+      () => "2huFztbeB4LijVCoLrxP8NwFbRCdtLfUyvx4VXwD5VnVxzxkMX"
     ],
     [
       "getBlockchainStatus",
       () => pchain.getBlockchainStatus(avalancheBlockChainID),
       (x) => x,
       Matcher.toBe,
-      () => "Created"
+      () => "Syncing"
     ],
     [
       "getCurrentSupply",

--- a/e2e_tests/xchain_nomock.test.ts
+++ b/e2e_tests/xchain_nomock.test.ts
@@ -28,7 +28,7 @@ describe("XChain", (): void => {
       () => keystore.createUser(user, passwd),
       (x) => x,
       Matcher.toEqual,
-      () => { return true }
+      () => { return {} }
     ],
     [
       "createaddrB",
@@ -90,7 +90,7 @@ describe("XChain", (): void => {
       () => xchain.getBalance(whaleAddr, "AVAX"),
       (x) => x.utxoIDs[0].txID,
       Matcher.toBe,
-      () => "BUuypiq2wyuLMvyhzFXcPyxPMCgSp7eeDohhQRqTChoBjKziC"
+      () => "28N55gFiYRrHWTopC4mybgvTw92x4EmWiZBLCRBgjXFyBgx9UN"
     ],
     [
       "importKey",

--- a/src/apis/platformvm/constants.ts
+++ b/src/apis/platformvm/constants.ts
@@ -44,6 +44,16 @@ export class PlatformVMConstants {
 
   static SECPCREDENTIAL: number = 9
 
+  // Camino
+  static CUSTOM_TYPE_ID: number = 8192
+  static LOCKEDINID: number = PlatformVMConstants.CUSTOM_TYPE_ID + 0
+  static LOCKEDOUTID: number = PlatformVMConstants.CUSTOM_TYPE_ID + 1
+  static CAMINOADDVALIDATORTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 2
+  static CAMINOREWARDVALIDATORTX: number =
+    PlatformVMConstants.CUSTOM_TYPE_ID + 3
+  static ADDADDRESSSTATETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 4
+
+  // Length Constants
   static ASSETIDLEN: number = 32
 
   static BLOCKCHAINIDLEN: number = 32

--- a/src/apis/platformvm/locked.ts
+++ b/src/apis/platformvm/locked.ts
@@ -1,0 +1,74 @@
+/**
+ * @packageDocumentation
+ * @module API-PlatformVM-Locked
+ */
+
+import { Buffer } from "buffer/"
+import BinTools from "../../utils/bintools"
+import { Serialization, SerializedEncoding } from "../../utils/serialization"
+
+const bintools: BinTools = BinTools.getInstance()
+const serialization: Serialization = Serialization.getInstance()
+
+export class SerializableTxID {
+  encode(encoding: SerializedEncoding = "hex"): string {
+    return serialization.encoder(this.txid, encoding, "Buffer", "cb58")
+  }
+
+  decode(value: string, encoding: SerializedEncoding = "hex") {
+    this.txid = serialization.decoder(value, encoding, "cb58", "Buffer", 32)
+  }
+
+  protected txid: Buffer = Buffer.alloc(32)
+
+  fromBuffer(bytes: Buffer, offset?: number): number {
+    this.txid = bintools.copyFrom(bytes, offset, offset + 32)
+    return offset + 32
+  }
+
+  toBuffer(): Buffer {
+    return this.txid
+  }
+}
+
+export class LockedIDs {
+  serialize(encoding: SerializedEncoding = "hex"): object {
+    let lockObj: object = {
+      depositTxID: this.depositTxID.encode(encoding),
+      bondTxID: this.bondTxID.encode(encoding)
+    }
+    return lockObj
+  }
+
+  deserialize(fields: object, encoding: SerializedEncoding = "hex") {
+    this.depositTxID.decode(fields["depositTxID"])
+    this.bondTxID.decode(fields["bondTxID"])
+  }
+
+  protected depositTxID: SerializableTxID = new SerializableTxID()
+  protected bondTxID: SerializableTxID = new SerializableTxID()
+
+  fromBuffer(bytes: Buffer, offset?: number): number {
+    offset = this.depositTxID.fromBuffer(bytes, offset)
+    offset = this.bondTxID.fromBuffer(bytes, offset)
+    return offset
+  }
+
+  toBuffer(): Buffer {
+    return Buffer.concat(
+      [this.depositTxID.toBuffer(), this.bondTxID.toBuffer()],
+      64
+    )
+  }
+
+  /**
+   * Class representing an [[LockedIDs]] for LockedIn and LockedOut types.
+   *
+   * @param depositTxID txID where this Output is deposited on
+   * @param bondTxID txID where this Output is bonded on
+   */
+  constructor(depositTxID?: Buffer, bondTxID?: Buffer) {
+    if (depositTxID) this.depositTxID.fromBuffer(depositTxID)
+    if (bondTxID) this.bondTxID.fromBuffer(bondTxID)
+  }
+}

--- a/src/apis/platformvm/outputs.ts
+++ b/src/apis/platformvm/outputs.ts
@@ -6,15 +6,16 @@ import { Buffer } from "buffer/"
 import BinTools from "../../utils/bintools"
 import { PlatformVMConstants } from "./constants"
 import {
+  BaseOutput,
   Output,
   StandardAmountOutput,
   StandardTransferableOutput,
-  StandardParseableOutput,
-  Address
+  StandardParseableOutput
 } from "../../common/output"
 import { Serialization, SerializedEncoding } from "../../utils/serialization"
 import BN from "bn.js"
 import { OutputIdError } from "../../utils/errors"
+import { LockedIDs } from "./locked"
 
 const bintools: BinTools = BinTools.getInstance()
 const serialization: Serialization = Serialization.getInstance()
@@ -26,13 +27,18 @@ const serialization: Serialization = Serialization.getInstance()
  *
  * @returns An instance of an [[Output]]-extended class.
  */
-export const SelectOutputClass = (outputid: number, ...args: any[]): Output => {
+export const SelectOutputClass = (
+  outputid: number,
+  ...args: any[]
+): BaseOutput => {
   if (outputid == PlatformVMConstants.SECPXFEROUTPUTID) {
     return new SECPTransferOutput(...args)
   } else if (outputid == PlatformVMConstants.SECPOWNEROUTPUTID) {
     return new SECPOwnerOutput(...args)
   } else if (outputid == PlatformVMConstants.STAKEABLELOCKOUTID) {
     return new StakeableLockOut(...args)
+  } else if (outputid == PlatformVMConstants.LOCKEDOUTID) {
+    return new LockedOut(...args)
   }
   throw new OutputIdError(
     "Error - SelectOutputClass: unknown outputid " + outputid
@@ -101,10 +107,6 @@ export abstract class AmountOutput extends StandardAmountOutput {
   makeTransferable(assetID: Buffer): TransferableOutput {
     return new TransferableOutput(assetID, this)
   }
-
-  select(id: number, ...args: any[]): Output {
-    return SelectOutputClass(id, ...args)
-  }
 }
 
 /**
@@ -135,38 +137,29 @@ export class SECPTransferOutput extends AmountOutput {
 }
 
 /**
- * An [[Output]] class which specifies an input that has a locktime which can also enable staking of the value held, preventing transfers but not validation.
+ * An [[Output]] class which specifies an output that has a locktime which can also enable
+ * staking of the value held, preventing transfers but not validation.
  */
-export class StakeableLockOut extends AmountOutput {
+export class StakeableLockOut extends ParseableOutput {
   protected _typeName = "StakeableLockOut"
   protected _typeID = PlatformVMConstants.STAKEABLELOCKOUTID
 
   //serialize and deserialize both are inherited
-
   serialize(encoding: SerializedEncoding = "hex"): object {
     let fields: object = super.serialize(encoding)
     let outobj: object = {
-      ...fields, //included anywayyyy... not ideal
+      ...fields,
       stakeableLocktime: serialization.encoder(
         this.stakeableLocktime,
         encoding,
         "Buffer",
         "decimalString",
         8
-      ),
-      transferableOutput: this.transferableOutput.serialize(encoding)
+      )
     }
-    delete outobj["addresses"]
-    delete outobj["locktime"]
-    delete outobj["threshold"]
-    delete outobj["amount"]
     return outobj
   }
   deserialize(fields: object, encoding: SerializedEncoding = "hex") {
-    fields["addresses"] = []
-    fields["locktime"] = "0"
-    fields["threshold"] = "1"
-    fields["amount"] = "99"
     super.deserialize(fields, encoding)
     this.stakeableLocktime = serialization.decoder(
       fields["stakeableLocktime"],
@@ -175,38 +168,12 @@ export class StakeableLockOut extends AmountOutput {
       "Buffer",
       8
     )
-    this.transferableOutput = new ParseableOutput()
-    this.transferableOutput.deserialize(fields["transferableOutput"], encoding)
-    this.synchronize()
   }
 
   protected stakeableLocktime: Buffer
-  protected transferableOutput: ParseableOutput
-
-  //call this every time you load in data
-  private synchronize() {
-    let output: AmountOutput =
-      this.transferableOutput.getOutput() as AmountOutput
-    this.addresses = output.getAddresses().map((a) => {
-      let addr: Address = new Address()
-      addr.fromBuffer(a)
-      return addr
-    })
-    this.numaddrs = Buffer.alloc(4)
-    this.numaddrs.writeUInt32BE(this.addresses.length, 0)
-    this.locktime = bintools.fromBNToBuffer(output.getLocktime(), 8)
-    this.threshold = Buffer.alloc(4)
-    this.threshold.writeUInt32BE(output.getThreshold(), 0)
-    this.amount = bintools.fromBNToBuffer(output.getAmount(), 8)
-    this.amountValue = output.getAmount()
-  }
 
   getStakeableLocktime(): BN {
     return bintools.fromBufferToBN(this.stakeableLocktime)
-  }
-
-  getTransferableOutput(): ParseableOutput {
-    return this.transferableOutput
   }
 
   /**
@@ -216,19 +183,13 @@ export class StakeableLockOut extends AmountOutput {
     return new TransferableOutput(assetID, this)
   }
 
-  select(id: number, ...args: any[]): Output {
-    return SelectOutputClass(id, ...args)
-  }
-
   /**
    * Popuates the instance from a {@link https://github.com/feross/buffer|Buffer} representing the [[StakeableLockOut]] and returns the size of the output.
    */
   fromBuffer(outbuff: Buffer, offset: number = 0): number {
     this.stakeableLocktime = bintools.copyFrom(outbuff, offset, offset + 8)
     offset += 8
-    this.transferableOutput = new ParseableOutput()
-    offset = this.transferableOutput.fromBuffer(outbuff, offset)
-    this.synchronize()
+    offset = super.fromBuffer(outbuff, offset)
     return offset
   }
 
@@ -236,10 +197,11 @@ export class StakeableLockOut extends AmountOutput {
    * Returns the buffer representing the [[StakeableLockOut]] instance.
    */
   toBuffer(): Buffer {
-    let xferoutBuff: Buffer = this.transferableOutput.toBuffer()
-    const bsize: number = this.stakeableLocktime.length + xferoutBuff.length
-    const barr: Buffer[] = [this.stakeableLocktime, xferoutBuff]
-    return Buffer.concat(barr, bsize)
+    const superBuf = super.toBuffer()
+    return Buffer.concat(
+      [this.stakeableLocktime, superBuf],
+      superBuf.length + 8
+    )
   }
 
   /**
@@ -260,14 +222,29 @@ export class StakeableLockOut extends AmountOutput {
   }
 
   /**
-   * A [[Output]] class which specifies a [[ParseableOutput]] that has a locktime which can also enable staking of the value held, preventing transfers but not validation.
+   * Returns the amount from the underlying output
+   */
+  getAmount(): BN {
+    return (this.getOutput() as StandardAmountOutput).getAmount()
+  }
+
+  /**
+   * Backwards compatibility
+   */
+  getTransferableOutput(): ParseableOutput {
+    return this
+  }
+
+  /**
+   * A [[Output]] class which specifies a [[ParseableOutput]] that has a locktime which can also
+   * enable staking of the value held, preventing transfers but not validation.
    *
    * @param amount A {@link https://github.com/indutny/bn.js/|BN} representing the amount in the output
    * @param addresses An array of {@link https://github.com/feross/buffer|Buffer}s representing addresses
    * @param locktime A {@link https://github.com/indutny/bn.js/|BN} representing the locktime
    * @param threshold A number representing the the threshold number of signers required to sign the transaction
    * @param stakeableLocktime A {@link https://github.com/indutny/bn.js/|BN} representing the stakeable locktime
-   * @param transferableOutput A [[ParseableOutput]] which is embedded into this output.
+   * @param output A [[BaseOutput]] which is embedded into this output.
    */
   constructor(
     amount: BN = undefined,
@@ -275,15 +252,15 @@ export class StakeableLockOut extends AmountOutput {
     locktime: BN = undefined,
     threshold: number = undefined,
     stakeableLocktime: BN = undefined,
-    transferableOutput: ParseableOutput = undefined
+    output: ParseableOutput = undefined
   ) {
-    super(amount, addresses, locktime, threshold)
+    super(
+      output
+        ? output.getOutput()
+        : new SECPTransferOutput(amount, addresses, locktime, threshold)
+    )
     if (typeof stakeableLocktime !== "undefined") {
       this.stakeableLocktime = bintools.fromBNToBuffer(stakeableLocktime, 8)
-    }
-    if (typeof transferableOutput !== "undefined") {
-      this.transferableOutput = transferableOutput
-      this.synchronize()
     }
   }
 }
@@ -321,8 +298,98 @@ export class SECPOwnerOutput extends Output {
     newout.fromBuffer(this.toBuffer())
     return newout as this
   }
+}
 
-  select(id: number, ...args: any[]): Output {
-    return SelectOutputClass(id, ...args)
+/**
+ * An [[Output]] class which specifies an output that is controlled by deposit and bond tx.
+ */
+export class LockedOut extends ParseableOutput {
+  protected _typeName = "LockedOut"
+  protected _typeID = PlatformVMConstants.LOCKEDOUTID
+
+  //serialize and deserialize both are inherited
+  serialize(encoding: SerializedEncoding = "hex"): object {
+    let fields: object = super.serialize(encoding)
+    let outobj: object = {
+      ...fields,
+      ids: this.ids.serialize()
+    }
+    return outobj
+  }
+
+  deserialize(fields: object, encoding: SerializedEncoding = "hex") {
+    super.deserialize(fields, encoding)
+    this.ids.deserialize(fields["ids"], encoding)
+  }
+
+  protected ids: LockedIDs = new LockedIDs()
+
+  /**
+   * @param assetID An assetID which is wrapped around the Buffer of the Output
+   */
+  makeTransferable(assetID: Buffer): TransferableOutput {
+    return new TransferableOutput(assetID, this)
+  }
+
+  create(...args: any[]): this {
+    return new LockedOut(...args) as this
+  }
+
+  clone(): this {
+    const newout: LockedOut = this.create()
+    newout.fromBuffer(this.toBuffer())
+    return newout as this
+  }
+
+  /**
+   * Popuates the instance from a {@link https://github.com/feross/buffer|Buffer} representing the [[LockedOut]] and returns the size of the output.
+   */
+  fromBuffer(outbuff: Buffer, offset: number = 0): number {
+    offset = this.ids.fromBuffer(outbuff, offset)
+    // Verify that outputId is
+    const outputid: number = bintools
+      .copyFrom(outbuff, offset, offset + 4)
+      .readUInt32BE(0)
+    offset += 4
+    offset = super.fromBuffer(outbuff, offset)
+    return offset
+  }
+
+  /**
+   * Returns the buffer representing the [[LockedOut]] instance.
+   */
+  toBuffer(): Buffer {
+    const idsBuf: Buffer = this.ids.toBuffer()
+    const superBuff: Buffer = super.toBuffer()
+    return Buffer.concat([idsBuf, superBuff], superBuff.length + 64)
+  }
+
+  /**
+   * Returns the outputID for this output
+   */
+  getOutputID(): number {
+    return this._typeID
+  }
+
+  /**
+   * Returns the amount from the underlying output
+   */
+  getAmount(): BN {
+    return (this.getOutput() as StandardAmountOutput).getAmount()
+  }
+
+  /**
+   * @param amount A {@link https://github.com/indutny/bn.js/|BN} representing the amount in the output
+   * @param addresses An array of {@link https://github.com/feross/buffer|Buffer}s representing addresses
+   * @param locktime A {@link https://github.com/indutny/bn.js/|BN} representing the locktime
+   * @param threshold A number representing the the threshold number of signers required to sign the transaction
+   */
+  constructor(
+    amount: BN = undefined,
+    addresses: Buffer[] = undefined,
+    locktime: BN = undefined,
+    threshold: number = undefined
+  ) {
+    super(new SECPTransferOutput(amount, addresses, locktime, threshold))
   }
 }

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -14,7 +14,11 @@ import { BaseTx } from "./basetx"
 import { ImportTx } from "./importtx"
 import { ExportTx } from "./exporttx"
 import { SerializedEncoding } from "../../utils/serialization"
-import { AddDelegatorTx, AddValidatorTx } from "./validationtx"
+import {
+  AddDelegatorTx,
+  AddValidatorTx,
+  CaminoAddValidatorTx
+} from "./validationtx"
 import { CreateSubnetTx } from "./createsubnettx"
 import { TransactionError } from "../../utils/errors"
 
@@ -41,6 +45,8 @@ export const SelectTxClass = (txtype: number, ...args: any[]): BaseTx => {
     return new AddDelegatorTx(...args)
   } else if (txtype === PlatformVMConstants.ADDVALIDATORTX) {
     return new AddValidatorTx(...args)
+  } else if (txtype === PlatformVMConstants.CAMINOADDVALIDATORTX) {
+    return new CaminoAddValidatorTx(...args)
   } else if (txtype === PlatformVMConstants.CREATESUBNETTX) {
     return new CreateSubnetTx(...args)
   }

--- a/src/apis/platformvm/validationtx.ts
+++ b/src/apis/platformvm/validationtx.ts
@@ -543,3 +543,49 @@ export class AddValidatorTx extends AddDelegatorTx {
     }
   }
 }
+
+export class CaminoAddValidatorTx extends AddValidatorTx {
+  protected _typeName = "CaminoAddValidatorTx"
+  protected _typeID = PlatformVMConstants.CAMINOADDVALIDATORTX
+
+  /**
+   * Class representing an unsigned CaminoAddValidatorTx transaction.
+   *
+   * @param networkID Optional. Networkid, [[DefaultNetworkID]]
+   * @param blockchainID Optional. Blockchainid, default Buffer.alloc(32, 16)
+   * @param outs Optional. Array of the [[TransferableOutput]]s
+   * @param ins Optional. Array of the [[TransferableInput]]s
+   * @param memo Optional. {@link https://github.com/feross/buffer|Buffer} for the memo field
+   * @param nodeID Optional. The node ID of the validator being added.
+   * @param startTime Optional. The Unix time when the validator starts validating the Primary Network.
+   * @param endTime Optional. The Unix time when the validator stops validating the Primary Network (and staked AVAX is returned).
+   * @param stakeAmount Optional. The amount of nAVAX the validator is staking.
+   * @param rewardOwners Optional. The [[ParseableOutput]] containing the [[SECPOwnerOutput]] for the rewards.
+   */
+  constructor(
+    networkID: number = DefaultNetworkID,
+    blockchainID: Buffer = Buffer.alloc(32, 16),
+    outs: TransferableOutput[] = undefined,
+    ins: TransferableInput[] = undefined,
+    memo: Buffer = undefined,
+    nodeID: Buffer = undefined,
+    startTime: BN = undefined,
+    endTime: BN = undefined,
+    stakeAmount: BN = undefined,
+    rewardOwners: ParseableOutput = undefined
+  ) {
+    super(
+      networkID,
+      blockchainID,
+      outs,
+      ins,
+      memo,
+      nodeID,
+      startTime,
+      endTime,
+      stakeAmount,
+      [],
+      rewardOwners
+    )
+  }
+}

--- a/src/common/tx.ts
+++ b/src/common/tx.ts
@@ -8,7 +8,11 @@ import { Credential } from "./credentials"
 import BN from "bn.js"
 import { StandardKeyChain, StandardKeyPair } from "./keychain"
 import { StandardAmountInput, StandardTransferableInput } from "./input"
-import { StandardAmountOutput, StandardTransferableOutput } from "./output"
+import {
+  StandardAmountOutput,
+  StandardParseableOutput,
+  StandardTransferableOutput
+} from "./output"
 import { DefaultNetworkID } from "../utils/constants"
 import {
   Serializable,
@@ -307,15 +311,15 @@ export abstract class StandardUnsignedTx<
     let total: BN = new BN(0)
 
     for (let i: number = 0; i < outs.length; i++) {
+      const inner = outs[`${i}`].getOutput()
+      const innerOut =
+        inner instanceof StandardParseableOutput ? inner.getOutput() : inner
       // only check StandardAmountOutput
       if (
-        outs[`${i}`].getOutput() instanceof StandardAmountOutput &&
+        innerOut instanceof StandardAmountOutput &&
         aIDHex === outs[`${i}`].getAssetID().toString("hex")
       ) {
-        const output: StandardAmountOutput = outs[
-          `${i}`
-        ].getOutput() as StandardAmountOutput
-        total = total.add(output.getAmount())
+        total = total.add(innerOut.getAmount())
       }
     }
     return total

--- a/src/common/utxos.ts
+++ b/src/common/utxos.ts
@@ -5,7 +5,7 @@
 import { Buffer } from "buffer/"
 import BinTools from "../utils/bintools"
 import BN from "bn.js"
-import { Output, StandardAmountOutput } from "./output"
+import { BaseOutput, StandardAmountOutput } from "./output"
 import { UnixNow } from "../utils/helperfunctions"
 import { MergeRule } from "../utils/constants"
 import {
@@ -85,7 +85,7 @@ export abstract class StandardUTXO extends Serializable {
   protected txid: Buffer = Buffer.alloc(32)
   protected outputidx: Buffer = Buffer.alloc(4)
   protected assetID: Buffer = Buffer.alloc(32)
-  protected output: Output = undefined
+  protected output: BaseOutput = undefined
 
   /**
    * Returns the numeric representation of the CodecID.
@@ -122,7 +122,7 @@ export abstract class StandardUTXO extends Serializable {
   /**
    * Returns a reference to the output
    */
-  getOutput = (): Output => this.output
+  getOutput = (): BaseOutput => this.output
 
   /**
    * Takes a {@link https://github.com/feross/buffer|Buffer} containing an [[StandardUTXO]], parses it, populates the class, and returns the length of the StandardUTXO in bytes.
@@ -168,7 +168,7 @@ export abstract class StandardUTXO extends Serializable {
     txid?: Buffer,
     outputidx?: Buffer | number,
     assetID?: Buffer,
-    output?: Output
+    output?: BaseOutput
   ): this
 
   /**
@@ -185,7 +185,7 @@ export abstract class StandardUTXO extends Serializable {
     txID: Buffer = undefined,
     outputidx: Buffer | number = undefined,
     assetID: Buffer = undefined,
-    output: Output = undefined
+    output: BaseOutput = undefined
   ) {
     super()
     if (typeof codecID !== "undefined") {

--- a/src/utils/bintools.ts
+++ b/src/utils/bintools.ts
@@ -369,6 +369,7 @@ export default class BinTools {
       humanReadablePart != "local" &&
       humanReadablePart != "columbus" &&
       humanReadablePart != "camino" &&
+      humanReadablePart != "kopernikus" &&
       humanReadablePart != "custom" &&
       humanReadablePart != hrp
     ) {

--- a/tests/apis/avm/outputs.test.ts
+++ b/tests/apis/avm/outputs.test.ts
@@ -6,7 +6,7 @@ import {
   SelectOutputClass,
   NFTMintOutput
 } from "../../../src/apis/avm/outputs"
-import { Output } from "../../../src/common/output"
+import { BaseOutput, Output } from "../../../src/common/output"
 import { SECPMintOutput } from "../../../src/apis/avm/outputs"
 import { AVMConstants } from "../../../src/apis/avm"
 
@@ -44,7 +44,7 @@ describe("Outputs", (): void => {
       const outpayment1: Output = new NFTMintOutput(1, addrs, fallLocktime, 1)
       const outpayment2: Output = new NFTMintOutput(2, addrs, fallLocktime, 1)
       const outpayment3: Output = new NFTMintOutput(0, addrs, fallLocktime, 1)
-      const cmp = Output.comparator()
+      const cmp = BaseOutput.comparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)
@@ -163,7 +163,7 @@ describe("Outputs", (): void => {
         locktime,
         3
       )
-      const cmp = Output.comparator()
+      const cmp = BaseOutput.comparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)

--- a/tests/apis/platformvm/outputs.test.ts
+++ b/tests/apis/platformvm/outputs.test.ts
@@ -5,7 +5,7 @@ import {
   SECPTransferOutput,
   SelectOutputClass
 } from "../../../src/apis/platformvm/outputs"
-import { Output } from "../../../src/common/output"
+import { BaseOutput, Output } from "../../../src/common/output"
 
 const bintools: BinTools = BinTools.getInstance()
 
@@ -28,7 +28,7 @@ describe("Outputs", (): void => {
         fallLocktime,
         1
       )
-      const outpayment: Output = SelectOutputClass(goodout.getOutputID())
+      const outpayment: BaseOutput = SelectOutputClass(goodout.getOutputID())
       expect(outpayment).toBeInstanceOf(SECPTransferOutput)
       expect(() => {
         SelectOutputClass(99)
@@ -54,7 +54,7 @@ describe("Outputs", (): void => {
         locktime,
         3
       )
-      const cmp = Output.comparator()
+      const cmp = BaseOutput.comparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)


### PR DESCRIPTION
## Implement CaminoAddValidatorTx and locked.Out
The CaminoGo implementation introduces some new types and tx types.

**Depositing**: Funds are locked while earning rewards.
**Bonding**: Funds are locked without earning rewards (e.g validator stake).
Deposited / bonded fFunds are not transferable
Deposited funds can be bonded, bonded funds can be deposited

```
- LOCKEDIN (An input type bound to deposit and/or bonding tx)
- LOCKEDOUT (An output type bound to deposit and/or bonding tx)
- CAMINOADDVALIDATORTX Our own AddValidatorTx implementation, must be used on Camino chain
- CAMINOREWARDVALIDATORTX transaction which is internally called at the end of the validator period
- ADDADDRESSSTATETX Our transaction to control access roles and kyc status
```

This PR implements LOCKEDOUT and CAMINOADDVALIDATORTX.
LOCKEDIN and ADDADDRESSSTATETX  has to be implemented as well, there is currently no need for CAMINOREWARDVALIDATORTX.