### PR TITLE
[TYPES] Add LockedIn

### DIFF
--- a/src/apis/platformvm/outputs.ts
+++ b/src/apis/platformvm/outputs.ts
@@ -346,11 +346,6 @@ export class LockedOut extends ParseableOutput {
    */
   fromBuffer(outbuff: Buffer, offset: number = 0): number {
     offset = this.ids.fromBuffer(outbuff, offset)
-    // Verify that outputId is
-    const outputid: number = bintools
-      .copyFrom(outbuff, offset, offset + 4)
-      .readUInt32BE(0)
-    offset += 4
     offset = super.fromBuffer(outbuff, offset)
     return offset
   }

--- a/src/apis/platformvm/utxos.ts
+++ b/src/apis/platformvm/utxos.ts
@@ -15,7 +15,6 @@ import {
   SECPTransferOutput
 } from "./outputs"
 import {
-  AmountInput,
   SECPTransferInput,
   StakeableLockIn,
   TransferableInput,
@@ -32,6 +31,7 @@ import {
   StandardAssetAmountDestination,
   AssetAmount
 } from "../../common/assetamount"
+import { BaseInput } from "../../common/input"
 import { BaseOutput } from "../../common/output"
 import { AddDelegatorTx, AddValidatorTx } from "./validationtx"
 import { CreateSubnetTx } from "./createsubnettx"
@@ -333,7 +333,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO> {
       const amount = amountOutput.getAmount()
 
       // Set up the SECP input with the same amount as the output.
-      let input: AmountInput = new SECPTransferInput(amount)
+      let input: BaseInput = new SECPTransferInput(amount)
 
       let locked: boolean = false
       if (output instanceof StakeableLockOut) {

--- a/tests/apis/avm/inputs.test.ts
+++ b/tests/apis/avm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/avm/outputs"
 import { AVMConstants } from "../../../src/apis/avm/constants"
-import { Input } from "../../../src/common/input"
+import { BaseInput } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 
 /**
@@ -119,7 +119,7 @@ describe("Inputs", (): void => {
     const inpt3: SECPTransferInput = new SECPTransferInput(
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
-    const cmp = Input.comparator()
+    const cmp = BaseInput.comparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)

--- a/tests/apis/evm/inputs.test.ts
+++ b/tests/apis/evm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/avm/outputs"
 import { EVMConstants } from "../../../src/apis/evm/constants"
-import { Input } from "../../../src/common/input"
+import { BaseInput } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 import { EVMInput } from "../../../src/apis/evm"
 
@@ -120,7 +120,7 @@ describe("Inputs", (): void => {
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
 
-    const cmp = Input.comparator()
+    const cmp = BaseInput.comparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)

--- a/tests/apis/platformvm/inputs.test.ts
+++ b/tests/apis/platformvm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/platformvm/outputs"
 import { PlatformVMConstants } from "../../../src/apis/platformvm/constants"
-import { Input } from "../../../src/common/input"
+import { BaseInput } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 
 /**
@@ -119,7 +119,7 @@ describe("Inputs", (): void => {
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
 
-    const cmp = Input.comparator()
+    const cmp = BaseInput.comparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)


### PR DESCRIPTION
## Add LockedIn input type
This PR follows #13 and implements the locked.In type used for Camino bonding and depositing TX.

- Rework StakeableLockedIn
- Implement LockedIn
- Fix LockedOut fromBuffer()