### PR TITLE
[PVM] BaseIn/Output interfaces

### DIFF
--- a/src/apis/avm/initialstates.ts
+++ b/src/apis/avm/initialstates.ts
@@ -5,7 +5,7 @@
 
 import { Buffer } from "buffer/"
 import BinTools from "../../utils/bintools"
-import { BaseOutput } from "../../common/output"
+import { BaseOutput, BaseOutputComparator } from "../../common/output"
 import { SelectOutputClass } from "./outputs"
 import { AVMConstants } from "./constants"
 import { Serializable, SerializedEncoding } from "../../utils/serialization"
@@ -101,7 +101,7 @@ export class InitialStates extends Serializable {
       const fxidbuff: Buffer = Buffer.alloc(4)
       fxidbuff.writeUInt32BE(fxid, 0)
       buff.push(fxidbuff)
-      const initialState = this.fxs[`${fxid}`].sort(BaseOutput.comparator())
+      const initialState = this.fxs[`${fxid}`].sort(BaseOutputComparator())
       const statelen: Buffer = Buffer.alloc(4)
       statelen.writeUInt32BE(initialState.length, 0)
       buff.push(statelen)

--- a/src/common/input.ts
+++ b/src/common/input.ts
@@ -18,43 +18,45 @@ import {
 const bintools: BinTools = BinTools.getInstance()
 const serialization: Serialization = Serialization.getInstance()
 
-export abstract class BaseInput extends Serializable {
-  abstract serialize(encoding: SerializedEncoding): object
-  abstract deserialize(fields: object, encoding: SerializedEncoding): void
-  abstract fromBuffer(bytes: Buffer, offset: number): number
-  abstract toBuffer(): Buffer
+export interface BaseInput {
+  getTypeID(): number
 
-  abstract getInput(): BaseInput
-  abstract getInputID(): number
-  abstract getCredentialID(): number
-  abstract addSignatureIdx(addressIdx: number, address: Buffer): void
-  abstract getSigIdxs(): SigIdx[]
+  serialize(encoding: SerializedEncoding): object
+  deserialize(fields: object, encoding: SerializedEncoding): void
+  fromBuffer(bytes: Buffer, offset: number): number
+  toBuffer(): Buffer
 
-  abstract clone(): this
-  abstract create(...args: any[]): this
+  getInput(): BaseInput
+  getInputID(): number
+  getCredentialID(): number
+  addSignatureIdx(addressIdx: number, address: Buffer): void
+  getSigIdxs(): SigIdx[]
 
-  static comparator =
-    (): ((a: BaseInput, b: BaseInput) => 1 | -1 | 0) =>
-    (a: BaseInput, b: BaseInput): 1 | -1 | 0 => {
-      const aoutid: Buffer = Buffer.alloc(4)
-      aoutid.writeUInt32BE(a.getInputID(), 0)
-      const abuff: Buffer = a.toBuffer()
-
-      const boutid: Buffer = Buffer.alloc(4)
-      boutid.writeUInt32BE(b.getInputID(), 0)
-      const bbuff: Buffer = b.toBuffer()
-
-      const asort: Buffer = Buffer.concat(
-        [aoutid, abuff],
-        aoutid.length + abuff.length
-      )
-      const bsort: Buffer = Buffer.concat(
-        [boutid, bbuff],
-        boutid.length + bbuff.length
-      )
-      return Buffer.compare(asort, bsort) as 1 | -1 | 0
-    }
+  clone(): this
+  create(...args: any[]): this
 }
+
+export const BaseInputComparator =
+  (): ((a: BaseInput, b: BaseInput) => 1 | -1 | 0) =>
+  (a: BaseInput, b: BaseInput): 1 | -1 | 0 => {
+    const aoutid: Buffer = Buffer.alloc(4)
+    aoutid.writeUInt32BE(a.getInputID(), 0)
+    const abuff: Buffer = a.toBuffer()
+
+    const boutid: Buffer = Buffer.alloc(4)
+    boutid.writeUInt32BE(b.getInputID(), 0)
+    const bbuff: Buffer = b.toBuffer()
+
+    const asort: Buffer = Buffer.concat(
+      [aoutid, abuff],
+      aoutid.length + abuff.length
+    )
+    const bsort: Buffer = Buffer.concat(
+      [boutid, bbuff],
+      boutid.length + bbuff.length
+    )
+    return Buffer.compare(asort, bsort) as 1 | -1 | 0
+  }
 
 export abstract class Input extends Serializable {
   protected _typeName = "Input"

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -21,43 +21,45 @@ import { ChecksumError, AddressError, AddressIndexError } from "../utils/errors"
 const bintools: BinTools = BinTools.getInstance()
 const serialization: Serialization = Serialization.getInstance()
 
-export abstract class BaseOutput extends Serializable {
-  abstract serialize(encoding: SerializedEncoding): object
-  abstract deserialize(fields: object, encoding: SerializedEncoding): void
-  abstract fromBuffer(bytes: Buffer, offset: number): number
-  abstract toBuffer(): Buffer
+export interface BaseOutput {
+  getTypeID(): number
 
-  abstract getThreshold(): number
-  abstract getLocktime(): BN
-  abstract getAddresses(): Buffer[]
-  abstract meetsThreshold(addrs: Buffer[], asOf: BN): boolean
+  serialize(encoding: SerializedEncoding): object
+  deserialize(fields: object, encoding: SerializedEncoding): void
+  fromBuffer(bytes: Buffer, offset: number): number
+  toBuffer(): Buffer
 
-  abstract getOutputID(): number
-  abstract clone(): this
-  abstract create(...args: any[]): this
+  getThreshold(): number
+  getLocktime(): BN
+  getAddresses(): Buffer[]
+  meetsThreshold(addrs: Buffer[], asOf: BN): boolean
 
-  static comparator =
-    (): ((a: BaseOutput, b: BaseOutput) => 1 | -1 | 0) =>
-    (a: BaseOutput, b: BaseOutput): 1 | -1 | 0 => {
-      const aoutid: Buffer = Buffer.alloc(4)
-      aoutid.writeUInt32BE(a.getOutputID(), 0)
-      const abuff: Buffer = a.toBuffer()
-
-      const boutid: Buffer = Buffer.alloc(4)
-      boutid.writeUInt32BE(b.getOutputID(), 0)
-      const bbuff: Buffer = b.toBuffer()
-
-      const asort: Buffer = Buffer.concat(
-        [aoutid, abuff],
-        aoutid.length + abuff.length
-      )
-      const bsort: Buffer = Buffer.concat(
-        [boutid, bbuff],
-        boutid.length + bbuff.length
-      )
-      return Buffer.compare(asort, bsort) as 1 | -1 | 0
-    }
+  getOutputID(): number
+  clone(): this
+  create(...args: any[]): this
 }
+
+export const BaseOutputComparator =
+  (): ((a: BaseOutput, b: BaseOutput) => 1 | -1 | 0) =>
+  (a: BaseOutput, b: BaseOutput): 1 | -1 | 0 => {
+    const aoutid: Buffer = Buffer.alloc(4)
+    aoutid.writeUInt32BE(a.getOutputID(), 0)
+    const abuff: Buffer = a.toBuffer()
+
+    const boutid: Buffer = Buffer.alloc(4)
+    boutid.writeUInt32BE(b.getOutputID(), 0)
+    const bbuff: Buffer = b.toBuffer()
+
+    const asort: Buffer = Buffer.concat(
+      [aoutid, abuff],
+      aoutid.length + abuff.length
+    )
+    const bsort: Buffer = Buffer.concat(
+      [boutid, bbuff],
+      boutid.length + bbuff.length
+    )
+    return Buffer.compare(asort, bsort) as 1 | -1 | 0
+  }
 
 /**
  * Class for representing an address used in [[Output]] types

--- a/tests/apis/avm/inputs.test.ts
+++ b/tests/apis/avm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/avm/outputs"
 import { AVMConstants } from "../../../src/apis/avm/constants"
-import { BaseInput } from "../../../src/common/input"
+import { BaseInputComparator } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 
 /**
@@ -119,7 +119,7 @@ describe("Inputs", (): void => {
     const inpt3: SECPTransferInput = new SECPTransferInput(
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
-    const cmp = BaseInput.comparator()
+    const cmp = BaseInputComparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)

--- a/tests/apis/avm/outputs.test.ts
+++ b/tests/apis/avm/outputs.test.ts
@@ -6,7 +6,7 @@ import {
   SelectOutputClass,
   NFTMintOutput
 } from "../../../src/apis/avm/outputs"
-import { BaseOutput, Output } from "../../../src/common/output"
+import { BaseOutputComparator, Output } from "../../../src/common/output"
 import { SECPMintOutput } from "../../../src/apis/avm/outputs"
 import { AVMConstants } from "../../../src/apis/avm"
 
@@ -44,7 +44,7 @@ describe("Outputs", (): void => {
       const outpayment1: Output = new NFTMintOutput(1, addrs, fallLocktime, 1)
       const outpayment2: Output = new NFTMintOutput(2, addrs, fallLocktime, 1)
       const outpayment3: Output = new NFTMintOutput(0, addrs, fallLocktime, 1)
-      const cmp = BaseOutput.comparator()
+      const cmp = BaseOutputComparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)
@@ -163,7 +163,7 @@ describe("Outputs", (): void => {
         locktime,
         3
       )
-      const cmp = BaseOutput.comparator()
+      const cmp = BaseOutputComparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)

--- a/tests/apis/evm/inputs.test.ts
+++ b/tests/apis/evm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/avm/outputs"
 import { EVMConstants } from "../../../src/apis/evm/constants"
-import { BaseInput } from "../../../src/common/input"
+import { BaseInputComparator } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 import { EVMInput } from "../../../src/apis/evm"
 
@@ -120,7 +120,7 @@ describe("Inputs", (): void => {
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
 
-    const cmp = BaseInput.comparator()
+    const cmp = BaseInputComparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)

--- a/tests/apis/platformvm/inputs.test.ts
+++ b/tests/apis/platformvm/inputs.test.ts
@@ -14,7 +14,7 @@ import {
   TransferableOutput
 } from "../../../src/apis/platformvm/outputs"
 import { PlatformVMConstants } from "../../../src/apis/platformvm/constants"
-import { BaseInput } from "../../../src/common/input"
+import { BaseInputComparator } from "../../../src/common/input"
 import { Output } from "../../../src/common/output"
 
 /**
@@ -119,7 +119,7 @@ describe("Inputs", (): void => {
       (utxos[2].getOutput() as AmountOutput).getAmount()
     )
 
-    const cmp = BaseInput.comparator()
+    const cmp = BaseInputComparator()
     expect(cmp(inpt1, inpt2)).toBe(-1)
     expect(cmp(inpt1, inpt3)).toBe(-1)
     expect(cmp(inpt1, inpt1)).toBe(0)

--- a/tests/apis/platformvm/outputs.test.ts
+++ b/tests/apis/platformvm/outputs.test.ts
@@ -5,7 +5,11 @@ import {
   SECPTransferOutput,
   SelectOutputClass
 } from "../../../src/apis/platformvm/outputs"
-import { BaseOutput, Output } from "../../../src/common/output"
+import {
+  BaseOutput,
+  BaseOutputComparator,
+  Output
+} from "../../../src/common/output"
 
 const bintools: BinTools = BinTools.getInstance()
 
@@ -54,7 +58,7 @@ describe("Outputs", (): void => {
         locktime,
         3
       )
-      const cmp = BaseOutput.comparator()
+      const cmp = BaseOutputComparator()
       expect(cmp(outpayment1, outpayment1)).toBe(0)
       expect(cmp(outpayment2, outpayment2)).toBe(0)
       expect(cmp(outpayment3, outpayment3)).toBe(0)


### PR DESCRIPTION
## BaseIn/Output interfaces (instead abstract class)
Next ES versions will fail to detect a ParseableOutput from BaseOutput while it is an abstract class.
Changing it to an interface fixes this, and it is quite more in line with the go implementation.
