### PR TITLE
Peak3d/regnode

### DIFF
--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -1,7 +1,7 @@
 import { Avalanche, Buffer } from "@c4tplatform/caminojs/dist"
 import { AVMAPI } from "@c4tplatform/caminojs/dist/apis/avm"
 import { UTXO, UTXOSet } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { Output } from "@c4tplatform/caminojs/dist/common"
+import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 // Change the networkID to affect the HRP of the bech32 encoded address
 // NetworkID - Bech32 Address - ChainPrefix-HRP1AddressChecksum
 //         0 - X-local19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
@@ -30,7 +30,7 @@ const main = async (): Promise<any> => {
   const utxos: UTXO[] = utxoset.getAllUTXOs()
 
   utxos.map((utxo: UTXO): void => {
-    const output: Output = utxo.getOutput()
+    const output: BaseOutput = utxo.getOutput()
     const addresses: string[] = output
       .getAddresses()
       .map((x: Buffer): string => xchain.addressFromBuffer(x))

--- a/examples/avm/buildCreateAssetTx.ts
+++ b/examples/avm/buildCreateAssetTx.ts
@@ -14,6 +14,7 @@ import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
 } from "@c4tplatform/caminojs/dist/utils"
+import { ExamplesConfig } from "common/examplesConfig"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")
 const avalanche: Avalanche = new Avalanche(

--- a/examples/index/getLastVertex.ts
+++ b/examples/index/getLastVertex.ts
@@ -1,7 +1,7 @@
-import { Avalanche, BinTools, Buffer } from "../../src"
-import { IndexAPI } from "../../src/apis/index/index"
-import { GetLastAcceptedResponse } from "../../src/apis/index/interfaces"
-import { Vertex } from "../../src/apis/avm"
+import { Avalanche, BinTools, Buffer } from "@c4tplatform/caminojs/dist"
+import { IndexAPI } from "@c4tplatform/caminojs/dist/apis/index/index"
+import { GetLastAcceptedResponse } from "@c4tplatform/caminojs/dist/apis/index/interfaces"
+import { Vertex } from "@c4tplatform/caminojs/dist/apis/avm"
 import { ExamplesConfig } from "../common/examplesConfig"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")

--- a/examples/index/traverseDAG.ts
+++ b/examples/index/traverseDAG.ts
@@ -1,10 +1,10 @@
-import { Avalanche, Buffer } from "../../src"
-import { Vertex } from "../../src/apis/avm"
-import { IndexAPI } from "../../src/apis/index"
+import { Avalanche, Buffer } from "@c4tplatform/caminojs/dist"
+import { Vertex } from "@c4tplatform/caminojs/dist/apis/avm"
+import { IndexAPI } from "@c4tplatform/caminojs/dist/apis/index"
 import {
   GetContainerByIndexResponse,
   GetLastAcceptedResponse
-} from "../../src/apis/index/interfaces"
+} from "@c4tplatform/caminojs/dist/apis/index/interfaces"
 
 import { ExamplesConfig } from "../common/examplesConfig"
 

--- a/examples/mnemonic/generateMnemonic.ts
+++ b/examples/mnemonic/generateMnemonic.ts
@@ -1,5 +1,7 @@
 import randomBytes from "randombytes"
 import Mnemonic from "@c4tplatform/caminojs/dist/utils/mnemonic"
+import { Buffer } from "buffer/"
+
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {
@@ -7,7 +9,7 @@ const main = async (): Promise<any> => {
   const wordlist = mnemonic.getWordlists("czech") as string[]
   const m: string = mnemonic.generateMnemonic(
     strength,
-    Buffer.from(randomBytes.toString()),
+    (size: number) => Buffer.from(randomBytes(size)),
     wordlist
   )
   console.log(m)

--- a/examples/platformvm/addDelegatorTx.ts
+++ b/examples/platformvm/addDelegatorTx.ts
@@ -15,7 +15,7 @@ import {
   SECPOwnerOutput,
   ParseableOutput
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { Output } from "@c4tplatform/caminojs/dist/common"
+import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
@@ -73,7 +73,9 @@ const main = async (): Promise<any> => {
 
   const stakeAmount: any = await pchain.getMinStake()
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee).sub(stakeAmount.minValidatorStake),
@@ -110,7 +112,7 @@ const main = async (): Promise<any> => {
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
   utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
+    const output: BaseOutput = utxo.getOutput()
     if (output.getOutputID() === 7) {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()

--- a/examples/platformvm/addSubnetValidatorTx.ts
+++ b/examples/platformvm/addSubnetValidatorTx.ts
@@ -85,7 +85,9 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),

--- a/examples/platformvm/addValidatorTx.ts
+++ b/examples/platformvm/addValidatorTx.ts
@@ -15,7 +15,7 @@ import {
   SECPOwnerOutput,
   ParseableOutput
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { Output } from "@c4tplatform/caminojs/dist/common"
+import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
@@ -74,7 +74,9 @@ const main = async (): Promise<any> => {
 
   const stakeAmount: any = await pchain.getMinStake()
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee).sub(stakeAmount.minValidatorStake),
@@ -111,7 +113,7 @@ const main = async (): Promise<any> => {
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
   utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
+    const output: BaseOutput = utxo.getOutput()
     if (output.getOutputID() === 7) {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()

--- a/examples/platformvm/baseTx-avax-create-multisig.ts
+++ b/examples/platformvm/baseTx-avax-create-multisig.ts
@@ -80,9 +80,9 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: GetBalanceResponse = await pchain.getBalance(
-    pAddressStrings[0]
-  )
+  const getBalanceResponse: GetBalanceResponse = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     balance.sub(fee),

--- a/examples/platformvm/buildExportTx-CChain.ts
+++ b/examples/platformvm/buildExportTx-CChain.ts
@@ -66,7 +66,9 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos

--- a/examples/platformvm/buildExportTx-XChain.ts
+++ b/examples/platformvm/buildExportTx-XChain.ts
@@ -67,7 +67,9 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos

--- a/examples/platformvm/buildRegisterNodeTx.ts
+++ b/examples/platformvm/buildRegisterNodeTx.ts
@@ -1,0 +1,75 @@
+import { Avalanche, Buffer } from "@c4tplatform/caminojs/dist"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  UnsignedTx,
+  Tx
+} from "@c4tplatform/caminojs/dist/apis/platformvm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey
+} from "@c4tplatform/caminojs/dist/utils"
+import { ExamplesConfig } from "../common/examplesConfig"
+
+const config: ExamplesConfig = require("../common/examplesConfig.json")
+const avalanche: Avalanche = new Avalanche(
+  config.host,
+  config.port,
+  config.protocol,
+  config.networkID
+)
+
+/**
+ * @ignore
+ */
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+
+let pchain: PlatformVMAPI
+let pKeychain: KeyChain
+let pAddresses: Buffer[]
+let pAddressStrings: string[]
+
+const InitAvalanche = async () => {
+  await avalanche.fetchNetworkSettings()
+  pchain = avalanche.PChain()
+  pKeychain = pchain.keyChain()
+  // P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+  pKeychain.importKey(privKey)
+  // NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL
+  pKeychain.importKey(
+    "PrivateKey-26ksbvjbz8jUTtzbCm3MYobKcDh22QPuPQX5dj2faQdR63TRdM"
+  )
+
+  pAddresses = pchain.keyChain().getAddresses()
+  pAddressStrings = pchain.keyChain().getAddressStrings()
+}
+
+const main = async (): Promise<any> => {
+  await InitAvalanche()
+
+  const oldNodeID = undefined
+  const newNodeID = "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL"
+  const addr = pAddresses[0]
+  const consortiumMemberAuthCredentials: [number, Buffer][] = [
+    [0, pAddresses[0]]
+  ]
+  const memo: Buffer = Buffer.from(
+    "Utility function to create a RegisterNodeTx transaction"
+  )
+
+  const unsignedTx: UnsignedTx = await pchain.buildRegisterNodeTx(
+    pAddressStrings,
+    pAddressStrings,
+    oldNodeID,
+    newNodeID,
+    addr,
+    consortiumMemberAuthCredentials,
+    memo
+  )
+
+  const tx: Tx = unsignedTx.sign(pKeychain)
+  const txid: string = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/createChainTx.ts
+++ b/examples/platformvm/createChainTx.ts
@@ -21,7 +21,7 @@ import {
   CreateChainTx,
   Tx
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { Output } from "@c4tplatform/caminojs/dist/common"
+import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
@@ -119,7 +119,9 @@ const main = async (): Promise<any> => {
     config.networkID
   )
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
@@ -139,7 +141,7 @@ const main = async (): Promise<any> => {
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
   utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
+    const output: BaseOutput = utxo.getOutput()
     if (output.getOutputID() === 7) {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()

--- a/examples/platformvm/createSubnetTx.ts
+++ b/examples/platformvm/createSubnetTx.ts
@@ -87,7 +87,9 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),

--- a/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
+++ b/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
@@ -87,7 +87,9 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),

--- a/examples/platformvm/exportTx-cchain.ts
+++ b/examples/platformvm/exportTx-cchain.ts
@@ -86,7 +86,9 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(

--- a/examples/platformvm/exportTx-xchain.ts
+++ b/examples/platformvm/exportTx-xchain.ts
@@ -17,11 +17,9 @@ import {
   Tx,
   ExportTx
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { Output } from "@c4tplatform/caminojs/dist/common"
 import {
   PrivateKeyPrefix,
-  DefaultLocalGenesisPrivateKey,
-  MILLIAVAX
+  DefaultLocalGenesisPrivateKey
 } from "@c4tplatform/caminojs/dist/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
 
@@ -81,7 +79,9 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
+  const getBalanceResponse: any = await pchain.getBalance({
+    address: pAddressStrings[0]
+  })
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
@@ -100,8 +100,6 @@ const main = async (): Promise<any> => {
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
   utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
-    // if (output.getOutputID() === 7) {
     const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
     const amt: BN = amountOutput.getAmount().clone()
     const txid: Buffer = utxo.getTxID()

--- a/examples/platformvm/getConfiguration.ts
+++ b/examples/platformvm/getConfiguration.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { GetConfigurationResponse } from "../../src/apis/platformvm/interfaces"
+import { Avalanche } from "@c4tplatform/caminojs/dist"
+import { GetConfigurationResponse } from "@c4tplatform/caminojs/dist/apis/platformvm/interfaces"
 import { ExamplesConfig } from "../common/examplesConfig"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")

--- a/src/apis/platformvm/camino_executor.ts
+++ b/src/apis/platformvm/camino_executor.ts
@@ -1,0 +1,145 @@
+/**
+ * @packageDocumentation
+ * @module API-PlatformVM-CaminoExecutor
+ */
+
+import BN from "bn.js"
+
+import { Buffer } from "buffer/"
+import { DefaultNetworkID } from "../../utils"
+import {
+  AssetAmountDestination,
+  PlatformVMAPI,
+  TransferableInput,
+  TransferableOutput,
+  UnsignedTx
+} from "."
+import { RegisterNodeTx } from "./registernodetx"
+
+type CaminoLockMode = "Unlocked" | "Bond" | "Deposit"
+
+export class CaminoExecutor {
+  platformAPI: PlatformVMAPI
+
+  constructor(platformAPI: PlatformVMAPI) {
+    this.platformAPI = platformAPI
+  }
+
+  spend = async (
+    aad: AssetAmountDestination,
+    lockMode: CaminoLockMode,
+    feeAssetID: Buffer = undefined
+  ): Promise<Error> => {
+    const addr = aad
+      .getSenders()
+      .map((a) => this.platformAPI.addressFromBuffer(a))
+    const changeAddr =
+      aad.getChangeAddresses().length > 0
+        ? this.platformAPI.addressFromBuffer(aad.getChangeAddresses()[0])
+        : ""
+
+    const aa = aad.getAssetAmount(feeAssetID.toString("hex"))
+
+    const result = await this.platformAPI.spend(
+      addr,
+      changeAddr,
+      lockMode,
+      aa.getAmount(),
+      aa.getBurn()
+    )
+
+    result.ins.forEach((inp) => {
+      aad.addInput(inp)
+    })
+    result.out.forEach((out) => {
+      aad.addOutput(out)
+    })
+
+    return
+  }
+
+  /**
+   * Build an unsigned [[RegisterNodeTx]].
+   *
+   * @param networkID Networkid, [[DefaultNetworkID]]
+   * @param blockchainID Blockchainid, default undefined
+   * @param fromAddresses The addresses being used to send the funds from the UTXOs {@link https://github.com/feross/buffer|Buffer}
+   * @param changeAddresses The addresses that can spend the change remaining from the spent UTXOs.
+   * @param oldNodeID Optional. ID of the existing NodeID to replace or remove.
+   * @param newNodeID Optional. ID of the newNodID to register address.
+   * @param address The consortiumMemberAddress, single or multi-sig.
+   * @param consortiumMemberAuthCredentials An array of index and address to sign for each SubnetAuth.
+   * @param fee Optional. The amount of fees to burn in its smallest denomination, represented as {@link https://github.com/indutny/bn.js/|BN}
+   * @param feeAssetID Optional. The assetID of the fees being burned
+   * @param memo Optional contains arbitrary bytes, up to 256 bytes
+   *
+   * @returns An unsigned RegisterNodeTx created from the passed in parameters.
+   */
+  buildRegisterNodeTx = async (
+    networkID: number = DefaultNetworkID,
+    blockchainID: Buffer,
+    fromAddresses: Buffer[],
+    changeAddresses: Buffer[],
+    oldNodeID: string | Buffer = undefined,
+    newNodeID: string | Buffer = undefined,
+    address: Buffer = undefined,
+    consortiumMemberAuthCredentials: [number, Buffer][] = [],
+    fee: BN = undefined,
+    feeAssetID: Buffer = undefined,
+    memo: Buffer = undefined
+  ): Promise<UnsignedTx> => {
+    const zero: BN = new BN(0)
+    let ins: TransferableInput[] = []
+    let outs: TransferableOutput[] = []
+
+    if (this._feeCheck(fee, feeAssetID)) {
+      const aad: AssetAmountDestination = new AssetAmountDestination(
+        fromAddresses,
+        fromAddresses,
+        changeAddresses
+      )
+      aad.addAssetAmount(feeAssetID, zero, fee)
+      const minSpendableErr: Error = await this.spend(
+        aad,
+        "Unlocked",
+        feeAssetID
+      )
+      if (typeof minSpendableErr === "undefined") {
+        ins = aad.getInputs()
+        outs = aad.getAllOutputs()
+      } else {
+        throw minSpendableErr
+      }
+    }
+
+    const registerNodeTx: RegisterNodeTx = new RegisterNodeTx(
+      networkID,
+      blockchainID,
+      outs,
+      ins,
+      memo,
+      oldNodeID,
+      newNodeID,
+      address
+    )
+    consortiumMemberAuthCredentials.forEach(
+      (subnetAuthCredential: [number, Buffer]): void => {
+        registerNodeTx.addSignatureIdx(
+          subnetAuthCredential[0],
+          subnetAuthCredential[1]
+        )
+      }
+    )
+
+    return new UnsignedTx(registerNodeTx)
+  }
+
+  _feeCheck(fee: BN, feeAssetID: Buffer): boolean {
+    return (
+      typeof fee !== "undefined" &&
+      typeof feeAssetID !== "undefined" &&
+      fee.gt(new BN(0)) &&
+      feeAssetID instanceof Buffer
+    )
+  }
+}

--- a/src/apis/platformvm/constants.ts
+++ b/src/apis/platformvm/constants.ts
@@ -52,6 +52,9 @@ export class PlatformVMConstants {
   static CAMINOREWARDVALIDATORTX: number =
     PlatformVMConstants.CUSTOM_TYPE_ID + 3
   static ADDADDRESSSTATETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 4
+  static DEPOSITTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 5
+  static UNLOCKDEPOSITTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 6
+  static REGISTERNODETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 7
 
   // Length Constants
   static ASSETIDLEN: number = 32

--- a/src/apis/platformvm/inputs.ts
+++ b/src/apis/platformvm/inputs.ts
@@ -102,6 +102,18 @@ export class TransferableInput extends StandardTransferableInput {
     this.input = SelectInputClass(inputid)
     return this.input.fromBuffer(bytes, offset)
   }
+
+  static fromArray(b: Buffer): TransferableInput[] {
+    var offset = 6 //version + counter
+    var num = b.readUInt32BE(2)
+    const result: TransferableInput[] = []
+    while (offset < b.length && num-- > 0) {
+      const t = new TransferableInput()
+      offset = t.fromBuffer(b, offset)
+      result.push(t)
+    }
+    return result
+  }
 }
 
 export abstract class AmountInput extends StandardAmountInput {

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -5,7 +5,7 @@
 
 import BN from "bn.js"
 import { PersistanceOptions } from "../../utils/persistenceoptions"
-import { TransferableOutput } from "."
+import { TransferableInput, TransferableOutput } from "."
 import { UTXOSet } from "../platformvm/utxos"
 
 export interface GetStakeParams {
@@ -220,4 +220,18 @@ export interface GetMaxStakeAmountParams {
   nodeID: string
   startTime: BN
   endTime: BN
+}
+
+export interface SpendParams {
+  from: string[] | string
+  changeAddr: string
+  lockMode: 0 | 1 | 2
+  amountToLock: string
+  amountToBurn: string
+  encoding?: string
+}
+
+export interface SpendReply {
+  ins: TransferableInput[]
+  out: TransferableOutput[]
 }

--- a/src/apis/platformvm/outputs.ts
+++ b/src/apis/platformvm/outputs.ts
@@ -71,6 +71,18 @@ export class TransferableOutput extends StandardTransferableOutput {
     this.output = SelectOutputClass(outputid)
     return this.output.fromBuffer(bytes, offset)
   }
+
+  static fromArray(b: Buffer): TransferableOutput[] {
+    var offset = 6 //version + counter
+    var num = b.readUInt32BE(2)
+    const result: TransferableOutput[] = []
+    while (offset < b.length && num-- > 0) {
+      const t = new TransferableOutput()
+      offset = t.fromBuffer(b, offset)
+      result.push(t)
+    }
+    return result
+  }
 }
 
 export class ParseableOutput extends StandardParseableOutput {

--- a/src/apis/platformvm/registernodetx.ts
+++ b/src/apis/platformvm/registernodetx.ts
@@ -1,0 +1,255 @@
+/**
+ * @packageDocumentation
+ * @module API-PlatformVM-RegisterNodeTx
+ */
+import { Buffer } from "buffer/"
+import BinTools from "../../utils/bintools"
+import { PlatformVMConstants } from "./constants"
+import { TransferableOutput } from "./outputs"
+import { TransferableInput } from "./inputs"
+import { Credential, SigIdx, Signature } from "../../common/credentials"
+import { BaseTx } from "./basetx"
+import { DefaultNetworkID } from "../../utils/constants"
+import {
+  bufferToNodeIDString,
+  NodeIDStringToBuffer
+} from "../../utils/helperfunctions"
+import { Serialization, SerializedEncoding } from "../../utils/serialization"
+import { SelectCredentialClass, SubnetAuth } from "."
+import { KeyChain, KeyPair } from "./keychain"
+
+/**
+ * @ignore
+ */
+const bintools: BinTools = BinTools.getInstance()
+const serialization: Serialization = Serialization.getInstance()
+
+/**
+ * Class representing an unsigned CreateChainTx transaction.
+ */
+export class RegisterNodeTx extends BaseTx {
+  protected _typeName = "RegisterNodeTx"
+  protected _typeID = PlatformVMConstants.REGISTERNODETX
+
+  serialize(encoding: SerializedEncoding = "hex"): object {
+    let fields: object = super.serialize(encoding)
+    return {
+      ...fields,
+      oldNodeID: bufferToNodeIDString(this.oldNodeID),
+      newNodeID: bufferToNodeIDString(this.newNodeID),
+      address: serialization.encoder(
+        this.consortiumMemberAddress,
+        encoding,
+        "Buffer",
+        "cb58"
+      )
+    }
+  }
+  deserialize(fields: object, encoding: SerializedEncoding = "hex") {
+    super.deserialize(fields, encoding)
+    this.oldNodeID = NodeIDStringToBuffer(fields["oldNodeID"])
+    this.newNodeID = NodeIDStringToBuffer(fields["newNodeID"])
+    this.consortiumMemberAddress = serialization.decoder(
+      fields["address"],
+      encoding,
+      "cb58",
+      "Buffer",
+      20
+    )
+  }
+
+  // Node id that will be unregistered for consortium member
+  protected oldNodeID: Buffer = Buffer.alloc(20)
+  // Node id that will be registered for consortium member
+  protected newNodeID: Buffer = Buffer.alloc(20)
+  // Auth that will be used to verify credential for [ConsortiumMemberAddress].
+  // If [ConsortiumMemberAddress] is msig-alias, auth must match real signatures.
+  protected consortiumMemberAuth: SubnetAuth
+  // Address of consortium member to which node id will be registered
+  protected consortiumMemberAddress: Buffer = Buffer.alloc(20)
+  // Signatures
+  protected sigCount: Buffer = Buffer.alloc(4)
+  protected sigIdxs: SigIdx[] = [] // idxs of subnet auth signers
+
+  /**
+   * Returns the id of the [[RegisterNodeTx]]
+   */
+  getTxType(): number {
+    return PlatformVMConstants.REGISTERNODETX
+  }
+
+  /**
+   * Returns the subnetAuth
+   */
+  getConsortiumMemberAuth(): SubnetAuth {
+    return this.consortiumMemberAuth
+  }
+
+  /**
+   * Takes a {@link https://github.com/feross/buffer|Buffer} containing an [[RegisterNodeTx]], parses it, populates the class, and returns the length of the [[RegisterNodeTx]] in bytes.
+   *
+   * @param bytes A {@link https://github.com/feross/buffer|Buffer} containing a raw [[RegisterNodeTx]]
+   *
+   * @returns The length of the raw [[RegisterNodeTx]]
+   *
+   * @remarks assume not-checksummed
+   */
+  fromBuffer(bytes: Buffer, offset: number = 0): number {
+    offset = super.fromBuffer(bytes, offset)
+    this.oldNodeID = bintools.copyFrom(bytes, offset, offset + 20)
+    offset += 20
+
+    this.newNodeID = bintools.copyFrom(bytes, offset, offset + 20)
+    offset += 20
+
+    const sa: SubnetAuth = new SubnetAuth()
+    offset += sa.fromBuffer(bintools.copyFrom(bytes, offset))
+    this.consortiumMemberAuth = sa
+
+    this.consortiumMemberAddress = bintools.copyFrom(bytes, offset, offset + 20)
+    offset += 20
+
+    return offset
+  }
+
+  /**
+   * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[RegisterNodeTx]].
+   */
+  toBuffer(): Buffer {
+    const superbuff: Buffer = super.toBuffer()
+
+    let bsize: number =
+      superbuff.length + this.oldNodeID.length + this.newNodeID.length
+
+    const barr: Buffer[] = [superbuff, this.oldNodeID, this.newNodeID]
+
+    bsize += this.consortiumMemberAuth.toBuffer().length
+    barr.push(this.consortiumMemberAuth.toBuffer())
+
+    bsize += this.consortiumMemberAddress.length
+    barr.push(this.consortiumMemberAddress)
+
+    return Buffer.concat(barr, bsize)
+  }
+
+  clone(): this {
+    const newRegisterNodeTx: RegisterNodeTx = new RegisterNodeTx()
+    newRegisterNodeTx.fromBuffer(this.toBuffer())
+    return newRegisterNodeTx as this
+  }
+
+  create(...args: any[]): this {
+    return new RegisterNodeTx(...args) as this
+  }
+
+  /**
+   * Creates and adds a [[SigIdx]] to the [[AddRegisterNodeTx]].
+   *
+   * @param addressIdx The index of the address to reference in the signatures
+   * @param address The address of the source of the signature
+   */
+  addSignatureIdx(addressIdx: number, address: Buffer): void {
+    const addressIndex: Buffer = Buffer.alloc(4)
+    addressIndex.writeUIntBE(addressIdx, 0, 4)
+    this.consortiumMemberAuth.addAddressIndex(addressIndex)
+
+    const sigidx: SigIdx = new SigIdx()
+    const b: Buffer = Buffer.alloc(4)
+    b.writeUInt32BE(addressIdx, 0)
+    sigidx.fromBuffer(b)
+    sigidx.setSource(address)
+    this.sigIdxs.push(sigidx)
+    this.sigCount.writeUInt32BE(this.sigIdxs.length, 0)
+  }
+
+  /**
+   * Returns the array of [[SigIdx]] for this [[Input]]
+   */
+  getSigIdxs(): SigIdx[] {
+    return this.sigIdxs
+  }
+
+  getCredentialID(): number {
+    return PlatformVMConstants.SECPCREDENTIAL
+  }
+
+  /**
+   * Takes the bytes of an [[UnsignedTx]] and returns an array of [[Credential]]s
+   *
+   * @param msg A Buffer for the [[UnsignedTx]]
+   * @param kc An [[KeyChain]] used in signing
+   *
+   * @returns An array of [[Credential]]s
+   */
+  sign(msg: Buffer, kc: KeyChain): Credential[] {
+    const creds: Credential[] = super.sign(msg, kc)
+    var cred: Credential = SelectCredentialClass(this.getCredentialID())
+
+    function addSig(source: Buffer) {
+      const keypair: KeyPair = kc.getKey(source)
+      const signval: Buffer = keypair.sign(msg)
+      const sig: Signature = new Signature()
+      sig.fromBuffer(signval)
+      cred.addSignature(sig)
+    }
+
+    // Add NodeSignature
+    if (
+      !this.newNodeID.every((v) => v === 0) &&
+      this.oldNodeID.every((v) => v === 0)
+    )
+      addSig(this.newNodeID)
+    creds.push(cred)
+
+    cred = SelectCredentialClass(this.getCredentialID())
+    const sigidxs: SigIdx[] = this.getSigIdxs()
+    for (let i: number = 0; i < sigidxs.length; i++) {
+      addSig(sigidxs[`${i}`].getSource())
+    }
+    creds.push(cred)
+    return creds
+  }
+
+  /**
+   * Class representing an unsigned RegisterNode transaction.
+   *
+   * @param networkID Optional networkID, [[DefaultNetworkID]]
+   * @param blockchainID Optional blockchainID, default Buffer.alloc(32, 16)
+   * @param outs Optional array of the [[TransferableOutput]]s
+   * @param ins Optional array of the [[TransferableInput]]s
+   * @param memo Optional {@link https://github.com/feross/buffer|Buffer} for the memo field
+   * @param oldNodeID Optional ID of the existing NodeID to replace or remove.
+   * @param newNodeID Optional ID of the newNodID to register address.
+   * @param address The consortiumMemberAddress, single or multi-sig.
+   */
+  constructor(
+    networkID: number = DefaultNetworkID,
+    blockchainID: Buffer = Buffer.alloc(32, 16),
+    outs: TransferableOutput[] = undefined,
+    ins: TransferableInput[] = undefined,
+    memo: Buffer = undefined,
+    oldNodeID: string | Buffer = undefined,
+    newNodeID: string | Buffer = undefined,
+    address: Buffer = undefined
+  ) {
+    super(networkID, blockchainID, outs, ins, memo)
+    if (typeof oldNodeID != "undefined") {
+      if (typeof oldNodeID === "string") {
+        this.oldNodeID = NodeIDStringToBuffer(oldNodeID)
+      } else {
+        this.oldNodeID = oldNodeID
+      }
+    }
+    if (typeof newNodeID != "undefined") {
+      if (typeof newNodeID === "string") {
+        this.newNodeID = NodeIDStringToBuffer(newNodeID)
+      } else {
+        this.newNodeID = newNodeID
+      }
+    }
+    if (typeof address != "undefined") {
+      this.consortiumMemberAddress = address
+    }
+    this.consortiumMemberAuth = new SubnetAuth()
+  }
+}

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -8,7 +8,7 @@ import { PlatformVMConstants } from "./constants"
 import { SelectCredentialClass } from "./credentials"
 import { KeyChain, KeyPair } from "./keychain"
 import { StandardTx, StandardUnsignedTx } from "../../common/tx"
-import { Credential } from "../../common/credentials"
+import { Credential, Signature } from "../../common/credentials"
 import createHash from "create-hash"
 import { BaseTx } from "./basetx"
 import { ImportTx } from "./importtx"
@@ -21,6 +21,7 @@ import {
 } from "./validationtx"
 import { CreateSubnetTx } from "./createsubnettx"
 import { TransactionError } from "../../utils/errors"
+import { SECPCredential } from "./credentials"
 
 /**
  * @ignore

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -1066,21 +1066,7 @@ describe("PlatformVMAPI", (): void => {
 
     beforeEach(async (): Promise<void> => {
       platformvm = new PlatformVMAPI(avalanche, "/ext/bc/P")
-      const result: Promise<Buffer> = platformvm.getAVAXAssetID()
-      const payload: object = {
-        result: {
-          name,
-          symbol,
-          assetID: bintools.cb58Encode(assetID),
-          denomination: `${denomination}`
-        }
-      }
-      const responseObj: HttpResponse = {
-        data: payload
-      }
-
-      mockAxios.mockResponse(responseObj)
-      await result
+      platformvm.setAVAXAssetID(assetID)
       set = new UTXOSet()
       lset = new UTXOSet()
       platformvm.newKeyChain()

--- a/tests/apis/platformvm/tx.test.ts
+++ b/tests/apis/platformvm/tx.test.ts
@@ -1,4 +1,3 @@
-import mockAxios from "jest-mock-axios"
 import { UTXOSet, UTXO } from "../../../src/apis/platformvm/utxos"
 import { PlatformVMAPI } from "../../../src/apis/platformvm/api"
 import { UnsignedTx, Tx } from "../../../src/apis/platformvm/tx"
@@ -18,14 +17,10 @@ import {
 import { PlatformVMConstants } from "../../../src/apis/platformvm/constants"
 import { Avalanche, GenesisData } from "../../../src/index"
 import { UTF8Payload } from "../../../src/utils/payload"
-import {
-  NodeIDStringToBuffer,
-  UnixNow
-} from "../../../src/utils/helperfunctions"
+import { UnixNow } from "../../../src/utils/helperfunctions"
 import { BaseTx } from "../../../src/apis/platformvm/basetx"
 import { ImportTx } from "../../../src/apis/platformvm/importtx"
 import { ExportTx } from "../../../src/apis/platformvm/exporttx"
-import { HttpResponse } from "jest-mock-axios/dist/lib/mock-axios-types"
 import { DefaultPlatformChainID } from "src/utils"
 
 describe("Transactions", (): void => {
@@ -92,21 +87,8 @@ describe("Transactions", (): void => {
       true
     )
     api = new PlatformVMAPI(avalanche, "/ext/bc/P")
-    const result: Promise<Buffer> = api.getAVAXAssetID()
-    const payload: object = {
-      result: {
-        name,
-        symbol,
-        assetID: bintools.cb58Encode(assetID),
-        denomination: `${denomination}`
-      }
-    }
-    const responseObj: HttpResponse = {
-      data: payload
-    }
-
-    mockAxios.mockResponse(responseObj)
-    avaxAssetID = await result
+    avaxAssetID = assetID
+    api.setAVAXAssetID(avaxAssetID)
   })
 
   beforeEach((): void => {


### PR DESCRIPTION
# PR implements the RegisterNodeTx to map an address to a NodeID
- Cleanup of existing example files
- Implementation of RegisterNodeTx including additional NodeSig and ConsortiumSig
- Example which build and executes the tx on kopernikus local network
Note: inputs / outputs are fetched from node using the new platformVm::spend API function