### PR TITLE
TECH-531 e2e test add validator

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,15 +49,17 @@ jobs:
       - name: Install autoremove
         run: sudo apt-get autoremove -y
       - name: Clone and Build Camino Node
+        env:
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.event.inputs.caminojsBranch }}
         run: |
           cd $GOPATH/$CAMPATH
-          git clone https://github.com/chain4travel/camino-node --depth 1 -bv0.3.1-alpha1
+          git clone https://github.com/chain4travel/camino-node --depth 1 -b$TARGET_BRANCH
           cd camino-node
           ./scripts/build.sh
       - name: Checkout Camino Network Runner
         run: |
           cd $GOPATH/$CAMPATH
-          git clone https://github.com/chain4travel/camino-network-runner --depth 1 -bv0.2.1-alpha1
+          git clone https://github.com/chain4travel/camino-network-runner --depth 1
       - name: Starting Camino Network Runner
         env:
           CAMINO_NODE_PATH: ${{env.GOPATH}}/${{env.CAMPATH}}/camino-node/build/camino-node
@@ -66,11 +68,30 @@ jobs:
           cd $GOPATH/$CAMPATH
           cd camino-network-runner
           go run ./examples/local/fivenodenetwork/main.go &>/tmp/cnr.log &
-      - name: CaminoJS E2E Test
+      - name: CaminoJS E2E Avax Tests
         env:
           CAMINOGO_IP: 127.0.0.1
           CAMINOGO_PORT: 9650
         run: |
           sleep 90
           cat /tmp/cnr.log
-          yarn test -i --roots e2e_tests
+          yarn test -i --roots e2e_tests --testPathIgnorePatterns=e2e_tests/camino
+      - name: Restarting Camino Network Runner with Kopernikus Configuration
+        env:
+          CAMINO_NODE_PATH: ${{env.GOPATH}}/${{env.CAMPATH}}/camino-node/build/camino-node
+          CAMINO_NETWORK: true
+        run: |
+          pkill -f camino-node
+          sleep 10
+          cd $GOPATH/$CAMPATH
+          cd camino-network-runner
+          go run ./examples/local/e2enodenetwork/main.go  &>/tmp/cnr-e2e.log &
+      - name: CaminoJS E2E Camino Tests
+        env:
+          CAMINOGO_IP: 127.0.0.1
+          CAMINOGO_PORT: 9650
+          NETWORK_ID: 1002
+        run: |
+          sleep 60
+          cat /tmp/cnr-e2e.log
+          yarn test -i --roots e2e_tests/camino

--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -1,0 +1,277 @@
+import { createTests, getAvalanche, Matcher } from "../e2etestlib"
+import { KeystoreAPI } from "src/apis/keystore/api"
+import BN from "bn.js"
+import { Tx, UnsignedTx } from "../../src/apis/platformvm"
+import { UnixNow } from "../../src/utils"
+import { Buffer } from "buffer/"
+
+const adminAddress = "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+const adminNodePrivateKey =
+  "PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE"
+const adminNodeId = "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL"
+const node6PrivateKey =
+  "PrivateKey-UfV3iPVP8ThZuSXmUacsahdzePs5VkXct4XoQKsW9mffN1d8J"
+const addrB = "X-kopernikus1s93gzmzuvv7gz8q4l83xccrdchh8mtm3xm5s2g"
+const addrBPrivateKey =
+  "PrivateKey-21QkTk3Zn2wxLd1WvRgWn1UpT5BC2Pz6caKbcsSpmuz7Qm8R7C"
+const node6Id = "NodeID-FHseEbTVS7U3odWfjgZYyygsv5gWCqVdk"
+const user: string = "avalancheJspChainUser"
+const passwd: string = "avalancheJsP@ssw4rd"
+const user2: string = "avalancheJspChainUser2"
+const passwd2: string = "avalancheJsP@ssw4rd2"
+const avalanche = getAvalanche()
+
+const startTime = UnixNow().add(new BN(60 * 1))
+const endTime: BN = startTime.add(new BN(26300000))
+const delegationFee: number = 10
+const threshold: number = 1
+const locktime: BN = new BN(0)
+const memo: Buffer = Buffer.from(
+  "PlatformVM utility method buildAddValidatorTx to add a validator to the primary subnet"
+)
+const P = function (s: string): string {
+  return "P" + s.substring(1)
+}
+
+let keystore: KeystoreAPI
+let tx = { value: "" }
+let xChain, pChain, pKeychain, pAddresses: any
+let createdSubnetID = { value: "" }
+let pAddressStrings: string[]
+
+beforeAll(async () => {
+  await avalanche.fetchNetworkSettings()
+  keystore = new KeystoreAPI(avalanche)
+  xChain = avalanche.XChain()
+  pChain = avalanche.PChain()
+  pKeychain = pChain.keyChain()
+  pKeychain.importKey(adminNodePrivateKey)
+  pKeychain.importKey(addrBPrivateKey)
+  pKeychain.importKey(node6PrivateKey)
+  pAddresses = pKeychain.getAddresses()
+  pAddressStrings = pKeychain.getAddressStrings()
+})
+
+describe("Camino-PChain-Add-Validator", (): void => {
+  const tests_spec: any = [
+    [
+      "assert pending validators=0",
+      () => pChain.getPendingValidators(),
+      (x) => x.validators.length,
+      Matcher.toBe,
+      () => 0
+    ],
+    [
+      "addValidator - with admin PK",
+      () =>
+        (async function () {
+          const stakeAmount: any = await pChain.getMinStake()
+          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+            undefined,
+            [P(adminAddress)],
+            [P(adminAddress)],
+            [P(adminAddress)],
+            adminNodeId,
+            startTime,
+            endTime,
+            stakeAmount.minValidatorStake,
+            [P(adminAddress)],
+            delegationFee,
+            locktime,
+            threshold,
+            memo
+          )
+
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.toThrow,
+      () => "couldn't issue tx: node is already a validator"
+    ],
+    [
+      "addValidator - with unregistered node",
+      () =>
+        (async function () {
+          const stakeAmount: any = await pChain.getMinStake()
+          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+            undefined,
+            [P(adminAddress)],
+            [P(adminAddress)],
+            [P(adminAddress)],
+            node6Id,
+            startTime,
+            endTime,
+            stakeAmount.minValidatorStake,
+            [P(adminAddress)],
+            delegationFee,
+            locktime,
+            threshold,
+            memo
+          )
+
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.toThrow,
+      () => "couldn't issue tx: no address registered for this node: not found"
+    ],
+
+    [
+      "createUser",
+      () => keystore.createUser(user, passwd),
+      (x) => x,
+      Matcher.toEqual,
+      () => {
+        return {}
+      }
+    ],
+    [
+      "register node6",
+      () =>
+        (async function () {
+          const consortiumMemberAuthCredentials: [number, Buffer][] = [
+            [0, pAddresses[1]]
+          ]
+          const unsignedTx: UnsignedTx = await pChain.buildRegisterNodeTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            undefined,
+            node6Id,
+            P(addrB),
+            consortiumMemberAuthCredentials,
+            memo
+          )
+
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => {
+        return x
+      },
+      Matcher.Get,
+      () => tx,
+      3000
+    ],
+    [
+      "verify register node tx has been committed",
+      () => pChain.getTxStatus(tx.value),
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "addValidator - return with node6 as a new consortium member",
+      () =>
+        (async function () {
+          const stakeAmount: any = await pChain.getMinStake()
+          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            [P(addrB)],
+            node6Id,
+            startTime,
+            endTime,
+            stakeAmount.minValidatorStake,
+            [P(addrB)],
+            delegationFee,
+            locktime,
+            threshold,
+            memo
+          )
+
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "verify addValidator tx has been committed",
+      () => pChain.getTxStatus(tx.value),
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "assert pending validators=1",
+      () => pChain.getPendingValidators(),
+      (x) => x.validators.length,
+      Matcher.toBe,
+      () => 1
+    ],
+    [
+      "create user2",
+      () => keystore.createUser(user2, passwd2),
+      (x) => x,
+      Matcher.toEqual,
+      () => {
+        return {}
+      }
+    ],
+    [
+      "importKey of user2",
+      () => pChain.importKey(user2, passwd2, addrBPrivateKey),
+      (x) => x,
+      Matcher.toBe,
+      () => "P" + addrB.substring(1)
+    ],
+    [
+      "createSubnet",
+      () => pChain.createSubnet(user2, passwd2, [P(addrB)], 1),
+      (x) => {
+        return x
+      },
+      Matcher.Get,
+      () => createdSubnetID
+    ],
+    [
+      "addSubnetValidator addrb",
+      () =>
+        (async function () {
+          const stakeAmount: any = await pChain.getMinStake()
+          const subnetAuthCredentials: [number, Buffer][] = [[0, pAddresses[1]]]
+          const nodeCredentials: [number, Buffer] = [2, pAddresses[2]]
+          const unsignedTx: UnsignedTx = await pChain.buildAddSubnetValidatorTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            node6Id,
+            startTime,
+            endTime,
+            stakeAmount.minValidatorStake,
+            createdSubnetID.value,
+            memo,
+            new BN(0),
+            subnetAuthCredentials,
+            nodeCredentials
+          )
+
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => {
+        return x
+      },
+      Matcher.Get,
+      () => tx,
+      3000
+    ],
+    [
+      "assert pending validators of subnet = 1",
+      () => pChain.getPendingValidators(createdSubnetID.value),
+      (x) => x.validators.length,
+      Matcher.toBe,
+      () => 1,
+      3000
+    ]
+  ]
+
+  createTests(tests_spec)
+})

--- a/e2e_tests/camino/xchain_nomock.test.ts
+++ b/e2e_tests/camino/xchain_nomock.test.ts
@@ -1,0 +1,224 @@
+import { getAvalanche, createTests, Matcher } from "../e2etestlib"
+import { KeystoreAPI } from "src/apis/keystore/api"
+import BN from "bn.js"
+
+const avalanche = getAvalanche()
+let keystore: KeystoreAPI
+let tx = { value: "" }
+let xChain: any
+let pChain: any
+
+beforeAll(async () => {
+  await avalanche.fetchNetworkSettings()
+  keystore = new KeystoreAPI(avalanche)
+  xChain = avalanche.XChain()
+  pChain = avalanche.PChain()
+})
+describe("Camino-XChain", (): void => {
+  let asset = { value: "" }
+  let addrB = { value: "" }
+  let addrC = { value: "" }
+
+  const user: string = "avalancheJsXChainUser"
+  const passwd: string = "avalancheJsP1ssw4rd"
+  const badUser: string = "asdfasdfsa"
+  const badPass: string = "pass"
+  const memo: string = "hello world"
+  const adminAddress: string =
+    "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+  const key: string =
+    "PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE"
+
+  const tests_spec: any = [
+    [
+      "createUser",
+      () => keystore.createUser(user, passwd),
+      (x) => x,
+      Matcher.toEqual,
+      () => {
+        return {}
+      }
+    ],
+    [
+      "createaddrB",
+      () => xChain.createAddress(user, passwd),
+      (x) => x,
+      Matcher.Get,
+      () => addrB
+    ],
+    [
+      "createaddrC",
+      () => xChain.createAddress(user, passwd),
+      (x) => x,
+      Matcher.Get,
+      () => addrC
+    ],
+    [
+      "incorrectUser",
+      () =>
+        xChain.send(
+          badUser,
+          passwd,
+          "CAM",
+          10,
+          addrB.value,
+          [addrC.value],
+          addrB.value,
+          memo
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () =>
+        `problem retrieving user "${badUser}": incorrect password for user "${badUser}"`
+    ],
+    [
+      "incorrectPass",
+      () =>
+        xChain.send(
+          user,
+          badPass,
+          "CAM",
+          10,
+          addrB.value,
+          [addrC.value],
+          addrB.value,
+          memo
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () =>
+        `problem retrieving user "${user}": incorrect password for user "${user}"`
+    ],
+    [
+      "importKey",
+      () => xChain.importKey(user, passwd, key),
+      (x) => x,
+      Matcher.toBe,
+      () => adminAddress
+    ],
+    [
+      "send",
+      () =>
+        xChain.send(
+          user,
+          passwd,
+          "CAM",
+          10,
+          addrB.value,
+          [adminAddress],
+          adminAddress,
+          memo
+        ),
+      (x) => x.txID,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "sendMultiple",
+      () =>
+        xChain.sendMultiple(
+          user,
+          passwd,
+          [
+            { assetID: "CAM", amount: 10, to: addrB.value },
+            { assetID: "CAM", amount: 20, to: addrC.value }
+          ],
+          [adminAddress],
+          adminAddress,
+          memo
+        ),
+      (x) => x.txID,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "listAddrs",
+      () => xChain.listAddresses(user, passwd),
+      (x) => x.sort(),
+      Matcher.toEqual,
+      () => [adminAddress, addrB.value, addrC.value].sort()
+    ],
+    [
+      "exportKey",
+      () => xChain.exportKey(user, passwd, addrB.value),
+      (x) => x,
+      Matcher.toMatch,
+      () => /PrivateKey-\w*/
+    ],
+    [
+      "export",
+      () =>
+        xChain.export(
+          user,
+          passwd,
+          "C" + addrB.value.substring(1),
+          new BN(10),
+          "CAM"
+        ),
+      (x) => x,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "import",
+      () => xChain.import(user, passwd, addrB.value, "P"),
+      (x) => x,
+      Matcher.toThrow,
+      () => "problem issuing transaction: no import inputs"
+    ],
+    [
+      "createFixed",
+      () =>
+        xChain.createFixedCapAsset(user, passwd, "Camino", "CAM", 0, [
+          { address: adminAddress, amount: "10000" }
+        ]),
+      (x) => x,
+      Matcher.Get,
+      () => asset
+    ],
+    [
+      "createVar",
+      () =>
+        xChain.createVariableCapAsset(user, passwd, "Camino", "CAM", 0, [
+          { minters: [adminAddress], threshold: 1 }
+        ]),
+      (x) => x,
+      Matcher.Get,
+      () => asset
+    ],
+    [
+      "mint",
+      () =>
+        xChain.mint(user, passwd, 1500, asset.value, addrB.value, [
+          adminAddress
+        ]),
+      (x) => x,
+      Matcher.toThrow,
+      () =>
+        "provided addresses don't have the authority to mint the provided asset"
+    ],
+    [
+      "getTx",
+      () => xChain.getTx(tx.value),
+      (x) => x,
+      Matcher.toMatch,
+      () => /\w+/
+    ],
+    [
+      "getTxStatus",
+      () => xChain.getTxStatus(tx.value),
+      (x) => x,
+      Matcher.toBe,
+      () => "Processing"
+    ],
+    [
+      "getAssetDesc",
+      () => xChain.getAssetDescription(asset.value),
+      (x) => [x.name, x.symbol],
+      Matcher.toEqual,
+      () => ["Camino", "CAM"]
+    ]
+  ]
+
+  createTests(tests_spec)
+})

--- a/e2e_tests/cchain_nomock.test.ts
+++ b/e2e_tests/cchain_nomock.test.ts
@@ -60,7 +60,7 @@ describe("CChain", (): void => {
       () => cchain.getBaseFee(),
       (x) => x,
       Matcher.toBe,
-      () => "0xba43b7400"
+      () => "0x34630b8a00"
     ],
     [
       "getMaxPriorityFeePerGas",

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -11,7 +11,7 @@ export const getAvalanche = (): Avalanche => {
     process.env.CAMINOGO_IP,
     parseInt(process.env.CAMINOGO_PORT),
     "http",
-    12345
+    process.env.NETWORK_ID ? parseInt(process.env.NETWORK_ID) : 12345
   )
   return avalanche
 }
@@ -26,8 +26,20 @@ export enum Matcher {
 }
 
 export const createTests = (tests_spec: any[]): void => {
-  for (const [testName, promise, preprocess, matcher, expected] of tests_spec) {
+  for (const [
+    testName,
+    promise,
+    preprocess,
+    matcher,
+    expected,
+    timeout = -1
+  ] of tests_spec) {
     test(testName, async (): Promise<void> => {
+      if (timeout > 0) {
+        jest.setTimeout(timeout * 2)
+        await new Promise((res) => setTimeout(res, timeout))
+        jest.setTimeout(5000) // default jest timeout
+      }
       if (matcher == Matcher.toBe) {
         expect(preprocess(await promise())).toBe(expected())
       }

--- a/e2e_tests/pchain_nomock.test.ts
+++ b/e2e_tests/pchain_nomock.test.ts
@@ -107,7 +107,7 @@ describe("PChain", (): void => {
       () => pchain.getBlockchains(),
       (x) => x[0].id,
       Matcher.toBe,
-      () => "2LqjNQWTVU7KEkFC5WenqdcwRzsjmJH1erk1xbFQDwt5EHC1Zr"
+      () => "27VLzZQ8SxuYiXWzov7wn5upEscX63KrweVDf6an5w45zqvJJv"
     ],
     [
       "getBlockchainsX",
@@ -130,7 +130,7 @@ describe("PChain", (): void => {
         return x.toString()
       },
       Matcher.toBe,
-      () => "361196333750752149"
+      () => "361210240952952649"
     ],
     [
       "getHeight",

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -1689,6 +1689,7 @@ export class PlatformVMAPI extends JRPCAPI {
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
     subnetAuthCredentials: [number, Buffer][] = [],
+    nodeCredentials: [number, Buffer] = undefined,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     const from: Buffer[] = this._cleanAddressArray(
@@ -1730,6 +1731,7 @@ export class PlatformVMAPI extends JRPCAPI {
       memo,
       asOf,
       subnetAuthCredentials,
+      nodeCredentials,
       changeThreshold
     )
 


### PR DESCRIPTION
## Why this should be merged
To add new e2e tests regarding addValidator functionality as well as adjust x-chain existing e2e tests on camino context.

## How this works
This PR consists of the following changes:

- tests as described in TECH-531 in regards to the various addValidator cases.
- e2e pipeline extension to test separately avax and camino compatible test cases (depends also on this [PR](https://github.com/chain4travel/camino-network-runner/pull/27)). The e2e changes also include the notion of TARGET_BRANCH so that caminojs "syncs" or rather test against the corresponding branch of the camino-node repository.
- avax-adjusted tests for xchain compatible with camino 

## How this was tested
Both manually and via automatic pipeline tests.
