### PR TITLE
[BN] Revert bn prototype overloading

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -548,7 +548,7 @@ export class AVMAPI extends JRPCAPI {
     const params: MintParams = {
       username: username,
       password: password,
-      amount: amnt,
+      amount: amnt.toString(10),
       assetID: asset,
       to,
       minters
@@ -770,7 +770,7 @@ export class AVMAPI extends JRPCAPI {
       username,
       password,
       to,
-      amount: amount,
+      amount: amount.toString(10),
       assetID
     }
     const response: RequestResponseData = await this.callMethod(

--- a/src/apis/avm/interfaces.ts
+++ b/src/apis/avm/interfaces.ts
@@ -48,7 +48,7 @@ export interface CreateVariableCapAssetParams extends CredsInterface {
 }
 
 export interface MintParams extends CredsInterface {
-  amount: number | BN
+  amount: number | string
   assetID: Buffer | string
   to: string
   minters: string[]
@@ -64,7 +64,7 @@ export interface ImportKeyParams extends CredsInterface {
 
 export interface ExportParams extends CredsInterface {
   to: string
-  amount: BN
+  amount: string
   assetID: string
 }
 

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -995,9 +995,9 @@ export class PlatformVMAPI extends JRPCAPI {
     }
 
     const params: GetMaxStakeAmountParams = {
-      nodeID,
-      startTime,
-      endTime
+      nodeID: nodeID,
+      startTime: startTime.toString(10),
+      endTime: endTime.toString(10)
     }
 
     if (typeof subnetID === "string") {
@@ -2329,16 +2329,20 @@ export class PlatformVMAPI extends JRPCAPI {
       from,
       to:
         to.length > 0
-          ? { locktime: toLockTime, threshold: toThreshold, addresses: to }
+          ? {
+              locktime: toLockTime.toString(10),
+              threshold: toThreshold,
+              addresses: to
+            }
           : undefined,
       change:
         change.length > 0
-          ? { locktime: ZeroBN, threshold: changeThreshold, addresses: change }
+          ? { locktime: "0", threshold: changeThreshold, addresses: change }
           : undefined,
       lockMode: lockMode === "Unlocked" ? 0 : lockMode === "Deposit" ? 1 : 2,
-      amountToLock: amountToLock,
-      amountToBurn: amountToBurn,
-      asOf: asOf,
+      amountToLock: amountToLock.toString(10),
+      amountToBurn: amountToBurn.toString(10),
+      asOf: asOf.toString(10),
       encoding: encoding ?? "hex"
     }
 

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -222,12 +222,12 @@ export interface GetMinStakeResponse {
 export interface GetMaxStakeAmountParams {
   subnetID?: string
   nodeID: string
-  startTime: BN
-  endTime: BN
+  startTime: string
+  endTime: string
 }
 
 export interface Owner {
-  locktime: BN
+  locktime: string
   threshold: number
   addresses: string[]
 }
@@ -242,9 +242,9 @@ export interface SpendParams {
   change?: Owner
 
   lockMode: 0 | 1 | 2
-  amountToLock: BN
-  amountToBurn: BN
-  asOf: BN
+  amountToLock: string
+  amountToBurn: string
+  asOf: string
   encoding?: string
 }
 

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -49,12 +49,6 @@ export class JRPCAPI extends APIBase {
       adapter: typeof fetch !== "undefined" ? fetchAdapter : undefined
     }
 
-    const prototypeBefore = BN.prototype.toJSON
-
-    BN.prototype.toJSON = function () {
-      return this.toString(10)
-    }
-
     const resp: RequestResponseData = await this.core.post(
       ep,
       {},
@@ -62,8 +56,6 @@ export class JRPCAPI extends APIBase {
       headrs,
       axConf
     )
-
-    BN.prototype.toJSON = prototypeBefore
 
     if (resp.status >= 200 && resp.status < 300) {
       this.rpcID += 1


### PR DESCRIPTION
## Revert BN prototype overloading
Fighting against vue prototype overloading leads to no proper / safe results.
All BN send to camino-node will now be serialized into 10-based string before json stringify applies.