### PR TITLE
Feature/tech 530 e2e test deposit tx

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,3 +95,34 @@ jobs:
           sleep 60
           cat /tmp/cnr-e2e.log
           yarn test -i --roots e2e_tests/camino
+      - name: Check produced logs
+        id: check-logs
+        run: |
+          export LOG_DIR=$(grep -Po '"log-dir": "[^"]*node1[^"]+"' /tmp/cnr-e2e.log | sed 's/"log-dir": "\(.*\)"/\1/')
+          grep -E 'FATAL |ERROR ' $LOG_DIR/*.log | cat > /tmp/parsed_logs
+          cat /tmp/parsed_logs
+          export errors=$(grep 'ERROR ' /tmp/parsed_logs | wc -l)
+          export fatal=$(grep 'FATAL' /tmp/parsed_logs | wc -l)
+          echo "errors=${errors}"  >> $GITHUB_OUTPUT
+          echo "fatal=${fatal}"  >> $GITHUB_OUTPUT
+          echo errors: ${errors}
+          echo fatal: ${fatal}
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "Found errors/fatal log records."
+      - name: Create PR comment if errors/fatal logs produced
+        if: ${{ steps.check-logs.outputs.errors > 0 || steps.check-logs.outputs.fatal > 0 }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id || '' }}
+          edit-mode: replace
+          body: |
+            :warning: Found errors/fatal log records. Please review them(job:e2e, step:"Check produced logs") and resolve this comment.
+            ```
+            ${{ steps.check-logs.outputs.errors }} errors
+            ${{ steps.check-logs.outputs.fatal }} fatal
+            ```

--- a/examples/platformvm/buildDepositTx.ts
+++ b/examples/platformvm/buildDepositTx.ts
@@ -8,6 +8,7 @@ import {
 import { OutputOwners } from "caminojs/common/output"
 import { PrivateKeyPrefix, DefaultLocalGenesisPrivateKey } from "caminojs/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
+import BN from "bn.js"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")
 const avalanche: Avalanche = new Avalanche(
@@ -39,6 +40,7 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
+  const amountToLock = new BN(1000000000)
   const depositOfferID = "wVVZinZkN9x6e9dh3DNNfrmdXaHPPwKWt3Zerx2vD8Ccuo6E7"
   const depositDuration = 110376000
   const memo: Buffer = Buffer.from(
@@ -57,7 +59,9 @@ const main = async (): Promise<any> => {
     depositOfferID,
     depositDuration,
     owners,
-    memo
+    memo,
+    new BN(0),
+    amountToLock
   )
 
   const tx: Tx = unsignedTx.sign(pKeychain)

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -41,6 +41,7 @@ import {
 import { GenesisData } from "../avm"
 import { DepositTx } from "./depositTx"
 import { AddressStateTx } from "./addressstatetx"
+import { UnlockDepositTx } from "./unlockdeposittx"
 
 export type LockMode = "Unlocked" | "Bond" | "Deposit" | "Stake"
 
@@ -1300,6 +1301,7 @@ export class Builder {
     feeAssetID: Buffer = undefined,
     memo: Buffer = undefined,
     asOf: BN = zero,
+    amountToLock: BN,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     let ins: TransferableInput[] = []
@@ -1316,13 +1318,13 @@ export class Builder {
         changeThreshold
       )
 
-      aad.addAssetAmount(feeAssetID, zero, fee)
+      aad.addAssetAmount(feeAssetID, amountToLock, fee)
 
       const minSpendableErr: Error = await this.spender.getMinimumSpendable(
         aad,
         asOf,
         zero,
-        "Unlocked"
+        "Deposit"
       )
       if (typeof minSpendableErr === "undefined") {
         ins = aad.getInputs()
@@ -1352,6 +1354,72 @@ export class Builder {
 
     baseTx.setOutputOwners(owners)
     return new UnsignedTx(baseTx)
+  }
+
+  /**
+   * Build an unsigned [[UnlockDepositTx]].
+   *
+   * @param networkID Networkid, [[DefaultNetworkID]]
+   * @param blockchainID Blockchainid, default undefined
+   * @param fromSigner @param fromSigner The addresses being used to send and verify the funds from the UTXOs {@link https://github.com/feross/buffer|Buffer}
+   * @param changeAddresses The addresses that can spend the change remaining from the spent UTXOs.
+   * @param fee Optional. The amount of fees to burn in its smallest denomination, represented as {@link https://github.com/indutny/bn.js/|BN}
+   * @param feeAssetID Optional. The assetID of the fees being burned
+   * @param memo Optional contains arbitrary bytes, up to 256 bytes
+   * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
+   * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
+   *
+   * @returns An unsigned UnlockDepositTx created from the passed in parameters.
+   */
+  buildUnlockDepositTx = async (
+    networkID: number = DefaultNetworkID,
+    blockchainID: Buffer,
+    fromSigner: FromSigner,
+    changeAddresses: Buffer[],
+    fee: BN = zero,
+    feeAssetID: Buffer = undefined,
+    memo: Buffer = undefined,
+    asOf: BN = zero,
+    changeThreshold: number = 1
+  ): Promise<UnsignedTx> => {
+    let ins: TransferableInput[] = []
+    let outs: TransferableOutput[] = []
+
+    if (this._feeCheck(fee, feeAssetID)) {
+      const aad: AssetAmountDestination = new AssetAmountDestination(
+        [],
+        0,
+        fromSigner.from,
+        fromSigner.signer,
+        changeAddresses,
+        changeThreshold
+      )
+
+      aad.addAssetAmount(feeAssetID, zero, fee)
+
+      const minSpendableErr: Error = await this.spender.getMinimumSpendable(
+        aad,
+        asOf,
+        zero,
+        "Unlocked"
+      )
+      if (typeof minSpendableErr === "undefined") {
+        ins = aad.getInputs()
+        outs = aad.getAllOutputs()
+      } else {
+        throw minSpendableErr
+      }
+    }
+
+    const unlockDepositTx: UnlockDepositTx = new UnlockDepositTx(
+      networkID,
+      blockchainID,
+      outs,
+      ins,
+      memo
+    )
+
+    return new UnsignedTx(unlockDepositTx)
   }
 
   _feeCheck(fee: BN, feeAssetID: Buffer): boolean {

--- a/src/apis/platformvm/unlockdeposittx.ts
+++ b/src/apis/platformvm/unlockdeposittx.ts
@@ -1,0 +1,31 @@
+/**
+ * @packageDocumentation
+ * @module API-PlatformVM-UnlockDepositTx
+ */
+import { PlatformVMConstants } from "./constants"
+import { BaseTx } from "./basetx"
+
+/**
+ * Class representing an unsigned UnlockDepositTx transaction.
+ */
+export class UnlockDepositTx extends BaseTx {
+  protected _typeName = "UnlockDepositTx"
+  protected _typeID = PlatformVMConstants.UNLOCKDEPOSITTX
+
+  /**
+   * Returns the id of the [[UnlockDepositTx]]
+   */
+  getTxType(): number {
+    return this._typeID
+  }
+
+  clone(): this {
+    const newUnlockDepositTx: UnlockDepositTx = new UnlockDepositTx()
+    newUnlockDepositTx.fromBuffer(this.toBuffer())
+    return newUnlockDepositTx as this
+  }
+
+  create(...args: any[]): this {
+    return new UnlockDepositTx(...args) as this
+  }
+}

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -366,7 +366,7 @@ export class OutputOwners extends Serializable {
    *
    * @param addresses An array of {@link https://github.com/feross/buffer|Buffer}s representing output owner's addresses
    * @param locktime A {@link https://github.com/indutny/bn.js/|BN} representing the locktime
-   * @param threshold A number representing the the threshold number of signers required to sign the transaction
+   * @param threshold A number representing the threshold number of signers required to sign the transaction
    */
   constructor(
     addresses: Buffer[] = undefined,


### PR DESCRIPTION
## Why this should be merged
To add new e2e tests regarding depositTx functionality as well as adjust x-chain existing e2e tests on camino context. (https://c4t.atlassian.net/browse/TECH-530)

## How this works
This PR consists of the following changes:
- tests as described in TECH-531 in regards to the various depositTx/unlockDepositTx cases.
- extension of the e2e pipeline to automatically add comments, in case log records of type ERROR or FATAL are produced by the nodes.

## How this was tested
Both manually and via automatic pipeline tests.
