### PR TITLE
Fix spend for ExportTx

### DIFF
--- a/examples/platformvm/buildExportTx-XChain.ts
+++ b/examples/platformvm/buildExportTx-XChain.ts
@@ -60,15 +60,11 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: any = await pchain.getBalance({
-    address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const unsignedTx: UnsignedTx = await pchain.buildExportTx(
     utxoSet,
-    unlocked.sub(fee),
+    new BN(1000000000),
     xChainBlockchainID,
     xAddressStrings,
     pAddressStrings,

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -371,9 +371,11 @@ export class Builder {
       changeThreshold
     )
 
+    var singleAsset = true
     if (amountAssetID.toString("hex") === feeAssetID.toString("hex")) {
       aad.addAssetAmount(amountAssetID, zero, fee.add(amount))
     } else {
+      singleAsset = false
       aad.addAssetAmount(amountAssetID, amount, zero)
       if (this._feeCheck(fee, feeAssetID)) {
         aad.addAssetAmount(feeAssetID, zero, fee)
@@ -388,8 +390,8 @@ export class Builder {
     )
     if (typeof minSpendableErr === "undefined") {
       ins = aad.getInputs()
-      outs = aad.getChangeOutputs()
-      exports = aad.getOutputs()
+      outs = singleAsset ? aad.getAllOutputs() : aad.getChangeOutputs()
+      exports = singleAsset ? [] : aad.getOutputs()
     } else {
       throw minSpendableErr
     }


### PR DESCRIPTION
## Fix spend for ExportTx
Our nodes Spend() API function does not support separate output of change and outputs.
Because of this fee + export amount is burned, and export out added separately (this is exactly what the builder in node is doing)

Before this fix all change was set as exported outs, and funds to export not properly set (in ExportTx)
This is fixed now: Change and Export amount are properly set in the transaction