### PR TITLE
[API] Return deserialized GetBalanceResponse

### DIFF
--- a/e2e_tests/pchain_nomock.test.ts
+++ b/e2e_tests/pchain_nomock.test.ts
@@ -76,14 +76,14 @@ describe("PChain", (): void => {
     [
       "getBalance",
       () => pchain.getBalance({ address: whaleAddr }),
-      (x) => x.balance,
+      (x) => x.balance.toString(10),
       Matcher.toBe,
       () => "30000000000000000"
     ],
     [
       "getBalanceOfMultipleAddresses",
       () => pchain.getBalance({ addresses: [whaleAddr] }),
-      (x) => x.balance,
+      (x) => x.balance.toString(10),
       Matcher.toBe,
       () => "30000000000000000"
     ],

--- a/examples/platformvm/addDelegatorTx.ts
+++ b/examples/platformvm/addDelegatorTx.ts
@@ -13,7 +13,9 @@ import {
   AddDelegatorTx,
   Tx,
   SECPOwnerOutput,
-  ParseableOutput
+  ParseableOutput,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
@@ -73,10 +75,10 @@ const main = async (): Promise<any> => {
 
   const stakeAmount: any = await pchain.getMinStake()
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee).sub(stakeAmount.minValidatorStake),
     pAddresses,

--- a/examples/platformvm/addSubnetValidatorTx.ts
+++ b/examples/platformvm/addSubnetValidatorTx.ts
@@ -11,7 +11,9 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx,
-  AddSubnetValidatorTx
+  AddSubnetValidatorTx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
@@ -85,10 +87,10 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
     avaxUTXOKeychain,

--- a/examples/platformvm/addValidatorTx.ts
+++ b/examples/platformvm/addValidatorTx.ts
@@ -13,7 +13,9 @@ import {
   AddValidatorTx,
   Tx,
   SECPOwnerOutput,
-  ParseableOutput
+  ParseableOutput,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
@@ -74,10 +76,10 @@ const main = async (): Promise<any> => {
 
   const stakeAmount: any = await pchain.getMinStake()
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee).sub(stakeAmount.minValidatorStake),
     pAddresses,

--- a/examples/platformvm/baseTx-avax-create-multisig.ts
+++ b/examples/platformvm/baseTx-avax-create-multisig.ts
@@ -11,9 +11,10 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx,
-  BaseTx
+  BaseTx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
-import { GetBalanceResponse } from "@c4tplatform/caminojs/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
@@ -78,10 +79,10 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: GetBalanceResponse = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const balance: BN = new BN(getBalanceResponse.balance)
+  })) as GetBalanceResponseAvax
+  const balance: BN = getBalanceResponse.balance
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     balance.sub(fee),
     pAddresses,

--- a/examples/platformvm/buildExportTx-CChain.ts
+++ b/examples/platformvm/buildExportTx-CChain.ts
@@ -8,12 +8,13 @@ import {
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx
+  Tx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
-  DefaultLocalGenesisPrivateKey,
-  UnixNow
+  DefaultLocalGenesisPrivateKey
 } from "@c4tplatform/caminojs/dist/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
 
@@ -60,10 +61,10 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const unsignedTx: UnsignedTx = await pchain.buildExportTx(

--- a/examples/platformvm/createChainTx.ts
+++ b/examples/platformvm/createChainTx.ts
@@ -19,13 +19,14 @@ import {
   AmountOutput,
   UnsignedTx,
   CreateChainTx,
-  Tx
+  Tx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import { BaseOutput } from "@c4tplatform/caminojs/dist/common"
 import {
   PrivateKeyPrefix,
-  DefaultLocalGenesisPrivateKey,
-  ONEAVAX
+  DefaultLocalGenesisPrivateKey
 } from "@c4tplatform/caminojs/dist/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
 
@@ -48,10 +49,8 @@ let pchain: PlatformVMAPI
 let pKeychain: KeyChain
 let pAddresses: Buffer[]
 let pAddressStrings: string[]
-let avaxAssetID: string
 let fee: BN
 let pChainBlockchainID: string
-let avaxAssetIDBuf: Buffer
 
 let avaxUTXOKeychain: Buffer[]
 let avaxUTXOKeychainStrings: string[]
@@ -76,10 +75,8 @@ const InitAvalanche = async () => {
   )
   pAddresses = pchain.keyChain().getAddresses()
   pAddressStrings = pchain.keyChain().getAddressStrings()
-  avaxAssetID = avalanche.getNetwork().X.avaxAssetID
   fee = pchain.getDefaultTxFee()
   pChainBlockchainID = avalanche.getNetwork().P.blockchainID
-  avaxAssetIDBuf = bintools.cb58Decode(avaxAssetID)
 
   avaxUTXOKeychain = [pAddresses[0], pAddresses[1]]
   avaxUTXOKeychainStrings = [pAddressStrings[0], pAddressStrings[1]]
@@ -119,10 +116,10 @@ const main = async (): Promise<any> => {
     config.networkID
   )
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
     avaxUTXOKeychain,

--- a/examples/platformvm/createSubnetTx.ts
+++ b/examples/platformvm/createSubnetTx.ts
@@ -12,7 +12,9 @@ import {
   UnsignedTx,
   CreateSubnetTx,
   Tx,
-  SECPOwnerOutput
+  SECPOwnerOutput,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
@@ -87,10 +89,10 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
     avaxUTXOKeychain,

--- a/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
+++ b/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
@@ -15,7 +15,9 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx,
-  ExportTx
+  ExportTx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
@@ -87,10 +89,10 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
     cAddresses,

--- a/examples/platformvm/exportTx-cchain.ts
+++ b/examples/platformvm/exportTx-cchain.ts
@@ -15,12 +15,13 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx,
-  ExportTx
+  ExportTx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
-  DefaultLocalGenesisPrivateKey,
-  MILLIAVAX
+  DefaultLocalGenesisPrivateKey
 } from "@c4tplatform/caminojs/dist/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
 
@@ -86,10 +87,10 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),

--- a/examples/platformvm/exportTx-xchain.ts
+++ b/examples/platformvm/exportTx-xchain.ts
@@ -15,7 +15,9 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx,
-  ExportTx
+  ExportTx,
+  GetBalanceResponse,
+  GetBalanceResponseAvax
 } from "@c4tplatform/caminojs/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
@@ -79,10 +81,10 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance({
+  const getBalanceResponse: GetBalanceResponse = (await pchain.getBalance({
     address: pAddressStrings[0]
-  })
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  })) as GetBalanceResponseAvax
+  const unlocked: BN = getBalanceResponse.unlocked
   console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),

--- a/examples/platformvm/getBalance.ts
+++ b/examples/platformvm/getBalance.ts
@@ -1,8 +1,13 @@
-import { Avalanche } from "@c4tplatform/caminojs/dist"
-import { PlatformVMAPI } from "@c4tplatform/caminojs/dist/apis/platformvm"
+import { Avalanche, BinTools } from "@c4tplatform/caminojs/dist"
+import {
+  PlatformVMAPI,
+  GetBalanceResponse
+} from "@c4tplatform/caminojs/dist/apis/platformvm"
 import { ExamplesConfig } from "../common/examplesConfig"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")
+const bintools: BinTools = BinTools.getInstance()
+
 const avalanche: Avalanche = new Avalanche(
   config.host,
   config.port,
@@ -11,26 +16,34 @@ const avalanche: Avalanche = new Avalanche(
 )
 
 let pchain: PlatformVMAPI = avalanche.PChain()
+let hrp: string
 
 const InitAvalanche = async () => {
   await avalanche.fetchNetworkSettings()
   pchain = avalanche.PChain()
+  hrp = avalanche.getNetwork().hrp
 }
 
 const main = async (): Promise<any> => {
   await InitAvalanche()
 
-  const address: string = "P-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2"
+  const toHrp = (s: string): string => {
+    return bintools.addressToString(hrp, "P", bintools.parseAddress(s, "P"))
+  }
+
+  const address: string = toHrp(
+    "P-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2"
+  )
   const addresses: string[] = [
-    "P-local1clz7hpsnrr6r9ukmjxn9wajgkhe3mgx8gqcm3a",
-    "P-local13w8m4qh6hay8fz3a4hzrs9k4wk4ytmfla756w2",
-    "P-local1hgjcjp3shkyxda8deyjlsde05g9fgwdk2xnwy3"
+    toHrp("P-local1clz7hpsnrr6r9ukmjxn9wajgkhe3mgx8gqcm3a"),
+    toHrp("P-local13w8m4qh6hay8fz3a4hzrs9k4wk4ytmfla756w2"),
+    toHrp("P-local1hgjcjp3shkyxda8deyjlsde05g9fgwdk2xnwy3")
   ]
-  const balance: object = await pchain.getBalance({
+  const balance: GetBalanceResponse = await pchain.getBalance({
     address,
     addresses
   })
-  console.log(balance)
+  console.log(JSON.stringify(balance, undefined, 2))
 }
 
 main()

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -33,6 +33,7 @@ import {
   DelegationFeeError
 } from "../../utils/errors"
 import {
+  BalanceDict,
   GetCurrentValidatorsParams,
   GetPendingValidatorsParams,
   GetRewardUTXOsParams,
@@ -473,7 +474,32 @@ export class PlatformVMAPI extends JRPCAPI {
       "platform.getBalance",
       params
     )
-    return response.data.result
+
+    const result = response.data.result
+
+    const parseDict = (input: any[]): BalanceDict => {
+      var dict: BalanceDict = {}
+      for (const [k, v] of Object.entries(input)) dict[k] = new BN(v)
+      return dict
+    }
+
+    if (this.core.getNetwork().P.lockModeBondDeposit) {
+      return {
+        balances: parseDict(result.balances),
+        unlockedOutputs: parseDict(result.unlockedOutputs),
+        bondedOutputs: parseDict(result.bondedOutputs),
+        depositedOutputs: parseDict(result.depositedOutputs),
+        bondedDepositedOutputs: parseDict(result.bondedDepositedOutputs),
+        utxoIDs: result.utxoIDs
+      } as GetBalanceResponse
+    }
+    return {
+      balance: new BN(result.balance),
+      unlocked: new BN(result.unlocked),
+      lockedStakeable: new BN(result.lockedStakeable),
+      lockedNotStakeable: new BN(result.lockedNotStakeable),
+      utxoIDs: result.utxoIDs
+    } as GetBalanceResponse
   }
 
   /**
@@ -2301,7 +2327,7 @@ export class PlatformVMAPI extends JRPCAPI {
       supplyCap: new BN(r.supplyCap),
       verifyNodeSignature: r.verifyNodeSignature ?? false,
       lockModeBondDeposit: r.lockModeBondDeposit ?? false
-    }
+    } as GetConfigurationResponse
   }
 
   /**

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -128,16 +128,35 @@ export interface ImportKeyParams {
   privateKey: string
 }
 
-export interface GetBalanceResponse {
-  balance: BN | number
-  unlocked: BN | number
-  lockedStakeable: BN | number
-  lockedNotStakeable: BN | number
-  utxoIDs: {
-    txID: string
-    outputIndex: number
-  }[]
+export interface UTXOID {
+  txID: string
+  outputIndex: number
 }
+
+export interface BalanceDict {
+  [assetId: string]: BN
+}
+
+export interface GetBalanceResponseAvax {
+  balance: BN
+  unlocked: BN
+  lockedStakeable: BN
+  lockedNotStakeable: BN
+  utxoIDs: UTXOID[]
+}
+
+export interface GetBalanceResponseCamino {
+  balances: BalanceDict
+  unlockedOutputs: BalanceDict
+  bondedOutputs: BalanceDict
+  depositedOutputs: BalanceDict
+  bondedDepositedOutputs: BalanceDict
+  utxoIDs: UTXOID[]
+}
+
+export type GetBalanceResponse =
+  | GetBalanceResponseAvax
+  | GetBalanceResponseCamino
 
 export interface CreateAddressParams {
   username: string

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -45,14 +45,12 @@ import {
   GetRewardUTXOsResponse,
   Subnet,
   GetTxStatusResponse,
-  GetValidatorsAtResponse
+  GetValidatorsAtResponse,
+  GetBalanceResponse,
+  GetUTXOsResponse
 } from "../../../src/apis/platformvm/interfaces"
 import { ErrorResponseObject } from "../../../src/utils/errors"
 import { HttpResponse } from "jest-mock-axios/dist/lib/mock-axios-types"
-import {
-  GetBalanceResponse,
-  GetUTXOsResponse
-} from "src/apis/platformvm/interfaces"
 import { Builder } from "../../../src/apis/platformvm/builder"
 
 /**
@@ -236,27 +234,32 @@ describe("PlatformVMAPI", (): void => {
   })
 
   test("getBalance", async (): Promise<void> => {
-    const balance: BN = new BN("100", 10)
-    const unlocked: BN = new BN("100", 10)
-    const lockedStakeable: BN = new BN("100", 10)
-    const lockedNotStakeable: BN = new BN("100", 10)
-    const respobj: GetBalanceResponse = {
-      balance,
-      unlocked,
-      lockedStakeable,
-      lockedNotStakeable,
-      utxoIDs: [
-        {
-          txID: "LUriB3W919F84LwPMMw4sm2fZ4Y76Wgb6msaauEY7i1tFNmtv",
-          outputIndex: 0
-        }
-      ]
+    const s100 = "100"
+    const b100 = new BN("100", 10)
+    const utxoIDs = [
+      {
+        txID: "LUriB3W919F84LwPMMw4sm2fZ4Y76Wgb6msaauEY7i1tFNmtv",
+        outputIndex: 0
+      }
+    ]
+    const expected: GetBalanceResponse = {
+      balance: b100,
+      unlocked: b100,
+      lockedStakeable: b100,
+      lockedNotStakeable: b100,
+      utxoIDs: utxoIDs
     }
     const result: Promise<GetBalanceResponse> = api.getBalance({
       address: addrA
     })
     const payload: object = {
-      result: respobj
+      result: {
+        balance: s100,
+        unlocked: s100,
+        lockedStakeable: s100,
+        lockedNotStakeable: s100,
+        utxoIDs: utxoIDs
+      }
     }
     const responseObj: HttpResponse = {
       data: payload
@@ -266,7 +269,7 @@ describe("PlatformVMAPI", (): void => {
     const response: object = await result
 
     expect(mockAxios.request).toHaveBeenCalledTimes(1)
-    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj))
+    expect(JSON.stringify(response)).toBe(JSON.stringify(expected))
   })
 
   test("getCurrentSupply", async (): Promise<void> => {


### PR DESCRIPTION
## [API] Return deserialized GetBalanceResponse
Until now getBalances json result was returned as an unparsed object, which differs from what is expected as return type (GetBalanceResponse). This PR parses the fields into it's right types.