### PR TITLE
Locked get methods

### DIFF
--- a/src/apis/platformvm/inputs.ts
+++ b/src/apis/platformvm/inputs.ts
@@ -295,6 +295,10 @@ export class LockedIn extends ParseableInput {
 
   protected ids: LockedIDs = new LockedIDs()
 
+  getLockedIDs(): LockedIDs {
+    return this.ids
+  }
+
   create(...args: any[]): this {
     return new LockedIn(...args) as this
   }

--- a/src/apis/platformvm/locked.ts
+++ b/src/apis/platformvm/locked.ts
@@ -21,6 +21,10 @@ export class SerializableTxID {
 
   protected txid: Buffer = Buffer.alloc(32)
 
+  isEmpty(): boolean {
+    return this.txid.equals(Buffer.alloc(32))
+  }
+
   fromBuffer(bytes: Buffer, offset?: number): number {
     this.txid = bintools.copyFrom(bytes, offset, offset + 32)
     return offset + 32
@@ -47,6 +51,13 @@ export class LockedIDs {
 
   protected depositTxID: SerializableTxID = new SerializableTxID()
   protected bondTxID: SerializableTxID = new SerializableTxID()
+
+  getDepositTxID(): SerializableTxID {
+    return this.depositTxID
+  }
+  getBondTxID(): SerializableTxID {
+    return this.bondTxID
+  }
 
   fromBuffer(bytes: Buffer, offset?: number): number {
     offset = this.depositTxID.fromBuffer(bytes, offset)

--- a/src/apis/platformvm/outputs.ts
+++ b/src/apis/platformvm/outputs.ts
@@ -336,6 +336,10 @@ export class LockedOut extends ParseableOutput {
 
   protected ids: LockedIDs = new LockedIDs()
 
+  getLockedIDs(): LockedIDs {
+    return this.ids
+  }
+
   /**
    * @param assetID An assetID which is wrapped around the Buffer of the Output
    */


### PR DESCRIPTION
## Add Getters to access LockedIn / Out fields
These getters allow implementations to work with LockedIn / Out types