### PR TITLE
Add getRegisteredShortIDLink and an example for that call

### DIFF
--- a/examples/platformvm/getRegisteredShortIDLink.ts
+++ b/examples/platformvm/getRegisteredShortIDLink.ts
@@ -1,0 +1,49 @@
+import { Avalanche } from "@c4tplatform/caminojs/dist"
+import {
+  KeyChain,
+  PlatformVMAPI
+} from "@c4tplatform/caminojs/dist/apis/platformvm"
+import { ExamplesConfig } from "../common/examplesConfig"
+import {
+  DefaultLocalGenesisPrivateKey,
+  PrivateKeyPrefix
+} from "@c4tplatform/caminojs/dist/utils"
+import { InfoAPI } from "@c4tplatform/caminojs/dist/apis/info"
+
+const config: ExamplesConfig = require("../common/examplesConfig.json")
+const avalanche: Avalanche = new Avalanche(
+  config.host,
+  config.port,
+  config.protocol,
+  config.networkID
+)
+
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+
+let pchain: PlatformVMAPI
+let pKeychain: KeyChain
+let pAddressStrings: string[]
+let info: InfoAPI
+
+const InitAvalanche = async () => {
+  await avalanche.fetchNetworkSettings()
+  pchain = avalanche.PChain()
+  pKeychain = pchain.keyChain()
+  pKeychain.importKey(privKey)
+  pAddressStrings = pchain.keyChain().getAddressStrings()
+  info = avalanche.Info()
+}
+
+const main = async (): Promise<any> => {
+  await InitAvalanche()
+
+  const resultNodeId: string = await pchain.getRegisteredShortIDLink(
+    pAddressStrings[0]
+  )
+  console.log(resultNodeId)
+  const nodeID: string = await info.getNodeID()
+  const resultAddress: string = await pchain.getRegisteredShortIDLink(nodeID)
+  console.log(resultAddress)
+}
+
+main()

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -556,6 +556,25 @@ export class PlatformVMAPI extends JRPCAPI {
     )
     return response.data.result
   }
+
+  /**
+   * A request that in address field accepts either a nodeID (and returns a bech32 address if it exists), or a bech32 address (and returns a NodeID if it exists).
+   *
+   * @param address A nodeID or a bech32 address
+   *
+   * @returns Promise for a string containing bech32 address that is the node owner or nodeID that the address passed is an owner of.
+   */
+  getRegisteredShortIDLink = async (address: string): Promise<string> => {
+    const params = {
+      address
+    }
+    const response: RequestResponseData = await this.callMethod(
+      "platform.getRegisteredShortIDLink",
+      params
+    )
+    return response.data.result.address
+  }
+
   /**
    * List amounts that can be claimed: validator rewards, expired deposit rewards, active deposit rewards claimable at current time.
    *


### PR DESCRIPTION
This PR adds getRegisteredShortIDLink to caminojs and an example that checks both NodeID passing and bech32 address passing to this method.