### PR TITLE
[Network] Init APIs fix for non-predefined networks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export default class Avalanche extends AvalancheCore {
   ) {
     super(host, port, protocol, networkID)
 
+    this.initCommonAPIs()
     if (networkID && networks.isPredefined(networkID)) {
       this.network = networks.getNetwork(networkID)
       this.networkID = networkID
@@ -156,7 +157,6 @@ export default class Avalanche extends AvalancheCore {
 
     const xchain = response.blockchains.find((b) => b["name"] === "X-Chain")
     const cchain = response.blockchains.find((b) => b["name"] === "C-Chain")
-
     const fees = await this.Info().getTxFee()
 
     this.network = {
@@ -210,14 +210,6 @@ export default class Avalanche extends AvalancheCore {
   }
 
   protected setupAPIs = (XChainID?: string, CChainID?: string): boolean => {
-    this.addAPI("admin", AdminAPI)
-    this.addAPI("auth", AuthAPI)
-    this.addAPI("health", HealthAPI)
-    this.addAPI("info", InfoAPI)
-    this.addAPI("index", IndexAPI)
-    this.addAPI("keystore", KeystoreAPI)
-    this.addAPI("metrics", MetricsAPI)
-
     this.addAPI("pchain", PlatformVMAPI)
     this.addAPI(
       "xchain",
@@ -233,6 +225,16 @@ export default class Avalanche extends AvalancheCore {
     )
 
     return true
+  }
+
+  protected initCommonAPIs = (): void => {
+    this.addAPI("admin", AdminAPI)
+    this.addAPI("auth", AuthAPI)
+    this.addAPI("health", HealthAPI)
+    this.addAPI("info", InfoAPI)
+    this.addAPI("index", IndexAPI)
+    this.addAPI("keystore", KeystoreAPI)
+    this.addAPI("metrics", MetricsAPI)
   }
 }
 


### PR DESCRIPTION
## Why this should be merged
To fix the issue that came up due to the following commit:
 _[Network] Fetch network always for non-predefined nets ->53aa7e40764800011894d86b76891275deb2294c_

More specifically, by not initializing the APIs in the constructor,
[ see removed code]
``` go    
if (!skipinit) {
      this.addAPI("admin", AdminAPI)
      this.addAPI("auth", AuthAPI)
      this.addAPI("health", HealthAPI)
      this.addAPI("info", InfoAPI)
      this.addAPI("index", IndexAPI)
      this.addAPI("keystore", KeystoreAPI)
      this.addAPI("metrics", MetricsAPI)
    }
```
 when a non-predefined network is initialized the [following Info API call leads to an error](https://github.com/chain4travel/caminojs/pull/42/commits/53aa7e40764800011894d86b76891275deb2294c#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R145) :  
_TypeError: Cannot read properties of undefined (reading 'getTxFee')_

``` go    
 this.networkID = await this.Info().getNetworkID()
```

This error was not detected by the pipeline tests earlier, as there were no tests with non-predefined networks yet. [This PR](https://github.com/chain4travel/caminojs/pull/26) though introduces such a case and that leads to [this](https://github.com/chain4travel/caminojs/actions/runs/4322062705/jobs/7544023780) pipeline failing.

## How this works
This PR re-introduces the initialization of certain common APIs. (including the Info API)

## How this was tested
Both manually and via automatic e2e camino tests.
