### PR TITLE
[E2E] Test auto deposit unlock

### DIFF
--- a/e2e_tests/camino/cchain_nomock.test.ts
+++ b/e2e_tests/camino/cchain_nomock.test.ts
@@ -3,11 +3,9 @@ import { KeystoreAPI } from "src/apis/keystore/api"
 import BN from "bn.js"
 import { costImportTx } from "src/utils"
 import { UTXOSet, Tx, UnsignedTx } from "src/apis/evm"
-import { avm, evm } from "src"
-import { Buffer } from "buffer"
+import { avm } from "src"
 import { GetUTXOsResponse } from "src/apis/avm"
-import {EVMCaminoConstants} from "../../src/apis/evm/camino_constants";
-const assert = require('assert');
+import { EVMCaminoConstants } from "../../src/apis/evm/camino_constants"
 
 const avalanche = getAvalanche()
 const user: string = "avalancheJspChainUser" + Math.random()
@@ -19,7 +17,7 @@ const adminPrivateKey =
 const gasFeeAddrPrivateKey =
   "PrivateKey-Ge71NJhUY3TjZ9dLohijSnNq46QxobjqxHGMUDAPoVsNFA93w"
 const kycAddrPrivateKey =
-    "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
+  "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 
 // c private keys
 const adminCPrivateKey =
@@ -95,34 +93,45 @@ beforeAll(async () => {
 })
 
 describe("Camino-CChain-Admin-Role", (): void => {
-  const dummyContractBin = "0x60806040523480156100115760006000fd5b50610017565b61016e806100266000396000f3fe60806040523480156100115760006000fd5b506004361061005c5760003560e01c806350f6fe3414610062578063aa8b1d301461006c578063b9b046f914610076578063d8b9839114610080578063e09fface1461008a5761005c565b60006000fd5b61006a610094565b005b6100746100ad565b005b61007e6100b5565b005b6100886100c2565b005b610092610135565b005b6000600090505b5b808060010191505061009b565b505b565b60006000fd5b565b600015156100bf57fe5b5b565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600d8152602001807f72657665727420726561736f6e0000000000000000000000000000000000000081526020015060200191505060405180910390fd5b565b5b56fea2646970667358221220345bbcbb1a5ecf22b53a78eaebf95f8ee0eceff6d10d4b9643495084d2ec934a64736f6c63430006040033"
+  const dummyContractBin =
+    "0x60806040523480156100115760006000fd5b50610017565b61016e806100266000396000f3fe60806040523480156100115760006000fd5b506004361061005c5760003560e01c806350f6fe3414610062578063aa8b1d301461006c578063b9b046f914610076578063d8b9839114610080578063e09fface1461008a5761005c565b60006000fd5b61006a610094565b005b6100746100ad565b005b61007e6100b5565b005b6100886100c2565b005b610092610135565b005b6000600090505b5b808060010191505061009b565b505b565b60006000fd5b565b600015156100bf57fe5b5b565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600d8152602001807f72657665727420726561736f6e0000000000000000000000000000000000000081526020015060200191505060405180910390fd5b565b5b56fea2646970667358221220345bbcbb1a5ecf22b53a78eaebf95f8ee0eceff6d10d4b9643495084d2ec934a64736f6c63430006040033"
 
   const tests_spec: any = [
     // Initial Role Check
     [
       "adminAddress role check",
-      () => contract.methods.hasRole(adminAddr, EVMCaminoConstants.ADMINROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(adminAddr, EVMCaminoConstants.ADMINROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => true
     ],
     [
       "gasFeeAddr role check",
-      () => contract.methods.hasRole(gasFeeAddr, EVMCaminoConstants.GASFEEROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(gasFeeAddr, EVMCaminoConstants.GASFEEROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => false
     ],
     [
       "kycAddr role check",
-      () => contract.methods.hasRole(kycAddr, EVMCaminoConstants.KYCROLE).call(),
+      () =>
+        contract.methods.hasRole(kycAddr, EVMCaminoConstants.KYCROLE).call(),
       (x) => x,
       Matcher.toEqual,
       () => false
     ],
     [
       "blacklistAddr role check",
-      () => contract.methods.hasRole(blacklistAddr, EVMCaminoConstants.BLACKLISTROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(blacklistAddr, EVMCaminoConstants.BLACKLISTROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => false
@@ -151,10 +160,10 @@ describe("Camino-CChain-Admin-Role", (): void => {
           user,
           passwd,
           "CAM",
-            900000000000,
+          900000000000,
           gasFeeXAddr,
           [adminAddress],
-            adminAddress,
+          adminAddress,
           "memo"
         ),
       (x) => x.txID,
@@ -205,7 +214,7 @@ describe("Camino-CChain-Admin-Role", (): void => {
             gasFeeAddr,
             [cAddressStrings[1]],
             avalanche.getNetwork().X.blockchainID,
-            cChain.getDefaultTxFee(),
+            cChain.getDefaultTxFee()
           )
           const importCost: number = costImportTx(
             avalanche.getNetwork().C,
@@ -218,7 +227,7 @@ describe("Camino-CChain-Admin-Role", (): void => {
             gasFeeAddr,
             [cAddressStrings[1]],
             avalanche.getNetwork().X.blockchainID,
-            fee,
+            fee
           )
 
           const tx: Tx = unsignedTx.sign(cChain.keyChain())
@@ -381,19 +390,19 @@ describe("Camino-CChain-Admin-Role", (): void => {
     [
       "SC deployment",
       async function () {
-          try {
-            const response: any = await contract.deploy({ data: dummyContractBin })
-              .send({ from: adminAddr, gas: 1000000 })
+        try {
+          const response: any = await contract
+            .deploy({ data: dummyContractBin })
+            .send({ from: adminAddr, gas: 1000000 })
 
-            if (response.options.address == null) {
-              throw "Contract was not deployed"
-            }
-            else {
-              throw "Contract was deployed"
-            }
-          } catch (e) {
-              return e
+          if (response.options.address == null) {
+            throw "Contract was not deployed"
+          } else {
+            throw "Contract was deployed"
           }
+        } catch (e) {
+          return e
+        }
       },
       (x) => x,
       Matcher.toBe,
@@ -409,14 +418,20 @@ describe("Camino-CChain-Gas-Fee-Role", (): void => {
     // Initial Role Check
     [
       "adminAddress role check",
-      () => contract.methods.hasRole(adminAddr, EVMCaminoConstants.ADMINROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(adminAddr, EVMCaminoConstants.ADMINROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => true
     ],
     [
       "gasFeeAddr role check",
-      () => contract.methods.hasRole(gasFeeAddr, EVMCaminoConstants.GASFEEROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(gasFeeAddr, EVMCaminoConstants.GASFEEROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => false
@@ -484,14 +499,18 @@ describe("Camino-CChain-KYC-Role", (): void => {
     // Initial Role Check
     [
       "adminAddress role check",
-      () => contract.methods.hasRole(adminAddr, EVMCaminoConstants.ADMINROLE).call(),
+      () =>
+        contract.methods
+          .hasRole(adminAddr, EVMCaminoConstants.ADMINROLE)
+          .call(),
       (x) => x,
       Matcher.toEqual,
       () => true
     ],
     [
       "kycAddr role check",
-      () => contract.methods.hasRole(kycAddr, EVMCaminoConstants.KYCROLE).call(),
+      () =>
+        contract.methods.hasRole(kycAddr, EVMCaminoConstants.KYCROLE).call(),
       (x) => x,
       Matcher.toEqual,
       () => false

--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -785,16 +785,23 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Half-Amount", (): void => {
 
 function getOneMinuteDepositOffer(): DepositOffer {
   return depositOffers.find((offer) => {
-    return offer.memo == "presale1min"
+    return (
+      Buffer.from(offer.memo.substring(2), "hex").toString() == "presale1min"
+    )
   })
 }
 function getLockedPresale3yDepositOffer(): DepositOffer {
   return depositOffers.find((offer) => {
-    return offer.memo == "lockedpresale3y"
+    return (
+      Buffer.from(offer.memo.substring(2), "hex").toString() ==
+      "lockedpresale3y"
+    )
   })
 }
 function getTest1DepositOffer(): DepositOffer {
   return depositOffers.find((offer) => {
-    return offer.memo.includes("depositOffer test#1")
+    return Buffer.from(offer.memo.substring(2), "hex")
+      .toString()
+      .includes("depositOffer test#1")
   })
 }

--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -4,7 +4,7 @@ import BN from "bn.js"
 import { DepositOffer, Tx, UnsignedTx } from "../../src/apis/platformvm"
 import { UnixNow } from "../../src/utils"
 import { Buffer } from "buffer/"
-import { OutputOwners } from "../../src/common"
+import { OutputOwners, ZeroBN } from "../../src/common"
 
 const adminAddress = "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
 const adminNodePrivateKey =
@@ -17,9 +17,9 @@ const addrC = "X-kopernikus1lx58kettrnt2kyr38adyrrmxt5x57u4vg4cfky"
 const addrBPrivateKey =
   "PrivateKey-21QkTk3Zn2wxLd1WvRgWn1UpT5BC2Pz6caKbcsSpmuz7Qm8R7C"
 const node6Id = "NodeID-FHseEbTVS7U3odWfjgZYyygsv5gWCqVdk"
-const user: string = "avalancheJspChainUser"
+const user: string = "avalancheJspChainUser" + Math.random()
 const passwd: string = "avalancheJsP@ssw4rd"
-const user2: string = "avalancheJspChainUser2"
+const user2: string = "avalancheJspChainUser2" + Math.random()
 const passwd2: string = "avalancheJsP@ssw4rd2"
 const avalanche = getAvalanche()
 
@@ -31,6 +31,7 @@ const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from(
   "PlatformVM utility method buildAddValidatorTx to add a validator to the primary subnet"
 )
+const interestRateDenominator = new BN(1_000_000 * (365 * 24 * 60 * 60))
 const P = function (s: string): string {
   return "P" + s.substring(1)
 }
@@ -43,15 +44,14 @@ const sumAllValues = function (map: Map<string, string>): BN {
 }
 
 let keystore: KeystoreAPI
-let depositOffers = {
-  value: undefined as DepositOffer[] | undefined
-}
+let depositOffers = undefined as DepositOffer[] | undefined
+let depositTx = { value: "" }
 let tx = { value: "" }
 let xChain, pChain, pKeychain, pAddresses: any
 let createdSubnetID = { value: "" }
 let pAddressStrings: string[]
 let balanceOutputs = { value: new Map() }
-
+let oneMinRewardsAmount: BN
 beforeAll(async () => {
   await avalanche.fetchNetworkSettings()
   keystore = new KeystoreAPI(avalanche)
@@ -63,6 +63,21 @@ beforeAll(async () => {
   pKeychain.importKey(node6PrivateKey)
   pAddresses = pKeychain.getAddresses()
   pAddressStrings = pKeychain.getAddressStrings()
+
+  // create user2
+  await keystore.createUser(user2, passwd2)
+  await pChain.importKey(user2, passwd2, addrBPrivateKey)
+
+  depositOffers = await pChain.getAllDepositOffers()
+  oneMinRewardsAmount = getOneMinuteDepositOffer()
+    .minAmount.mul(
+      new BN(
+        getOneMinuteDepositOffer().minDuration -
+          getOneMinuteDepositOffer().noRewardsPeriodDuration
+      )
+    )
+    .mul(getOneMinuteDepositOffer().interestRateNominator)
+    .div(interestRateDenominator)
 })
 
 describe("Camino-PChain-Add-Validator", (): void => {
@@ -219,22 +234,7 @@ describe("Camino-PChain-Add-Validator", (): void => {
       Matcher.toBe,
       () => 1
     ],
-    [
-      "create user2",
-      () => keystore.createUser(user2, passwd2),
-      (x) => x,
-      Matcher.toEqual,
-      () => {
-        return {}
-      }
-    ],
-    [
-      "importKey of user2",
-      () => pChain.importKey(user2, passwd2, addrBPrivateKey),
-      (x) => x,
-      Matcher.toBe,
-      () => "P" + addrB.substring(1)
-    ],
+
     [
       "createSubnet",
       () => pChain.createSubnet(user2, passwd2, [P(addrB)], 1),
@@ -290,24 +290,13 @@ describe("Camino-PChain-Add-Validator", (): void => {
 
   createTests(tests_spec)
 })
-
 describe("Camino-PChain-Deposit", (): void => {
   const tests_spec: any = [
-    [
-      "Get all deposit offers",
-      () => pChain.getAllDepositOffers(),
-      (x) => x,
-      Matcher.Get,
-      () => depositOffers
-    ],
     [
       "Issue depositTx with inactive offer",
       () =>
         (async function () {
-          const inactiveOffer: DepositOffer = getFirstDepositOfferWithFlag(
-            depositOffers.value,
-            1
-          )
+          const inactiveOffer: DepositOffer = getLockedPresale3yDepositOffer()
           const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
             undefined,
             [P(addrB)],
@@ -330,10 +319,7 @@ describe("Camino-PChain-Deposit", (): void => {
       "Issue depositTx with duration < minDuration",
       () =>
         (async function () {
-          const activeOffer: DepositOffer = getFirstDepositOfferWithFlag(
-            depositOffers.value,
-            0
-          )
+          const activeOffer: DepositOffer = getTest1DepositOffer()
           const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
             undefined,
             [P(addrB)],
@@ -357,10 +343,7 @@ describe("Camino-PChain-Deposit", (): void => {
       "Issue depositTx with duration > maxDuration",
       () =>
         (async function () {
-          const activeOffer: DepositOffer = getFirstDepositOfferWithFlag(
-            depositOffers.value,
-            0
-          )
+          const activeOffer: DepositOffer = getTest1DepositOffer()
           const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
             undefined,
             [P(addrB)],
@@ -391,10 +374,7 @@ describe("Camino-PChain-Deposit", (): void => {
       "Issue depositTx with insufficient unlocked funds",
       () =>
         (async function () {
-          const activeOffer: DepositOffer = getFirstDepositOfferWithFlag(
-            depositOffers.value,
-            0
-          )
+          const activeOffer: DepositOffer = getTest1DepositOffer()
           const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
             undefined,
             [P(addrC)],
@@ -417,16 +397,13 @@ describe("Camino-PChain-Deposit", (): void => {
       "Issue depositTx",
       () =>
         (async function () {
-          const activeOffer: DepositOffer = getFirstDepositOfferWithFlag(
-            depositOffers.value,
-            0
-          )
+          const activeOffer: DepositOffer = getTest1DepositOffer()
           const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
             undefined,
             [P(addrB)],
             [P(addrB)],
             activeOffer.id,
-            activeOffer.minDuration,
+            activeOffer.maxDuration,
             new OutputOwners([pAddresses[1]]),
             memo,
             new BN(0),
@@ -460,7 +437,7 @@ describe("Camino-PChain-Deposit", (): void => {
       () =>
         sumAllValues(balanceOutputs.value["depositedOutputs"]).add(
           sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]).add(
-            getFirstDepositOfferWithFlag(depositOffers.value, 0).minAmount
+            getTest1DepositOffer().minAmount
           )
         )
     ],
@@ -513,12 +490,311 @@ describe("Camino-PChain-Deposit", (): void => {
   ]
   createTests(tests_spec)
 })
+describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
+  const tests_spec: any = [
+    [
+      "Get balance outputs",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => x,
+      Matcher.Get,
+      () => balanceOutputs
+    ],
+    [
+      "Issue depositTx -> presale1min",
+      () =>
+        (async function () {
+          const activeOffer: DepositOffer = getOneMinuteDepositOffer()
+          const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            activeOffer.id,
+            activeOffer.minDuration,
+            new OutputOwners([pAddresses[1]]),
+            memo,
+            new BN(0),
+            activeOffer.minAmount
+          )
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "Verify tx has been committed",
+      () => {
+        return pChain.getTxStatus(tx.value)
+      },
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "Verify deposited/depositedBonded amounts haven been appropriately increased",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) =>
+        sumAllValues(x.depositedOutputs).add(
+          sumAllValues(x.bondedDepositedOutputs)
+        ),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["depositedOutputs"]).add(
+          sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]).add(
+            getOneMinuteDepositOffer().minAmount
+          )
+        )
+    ],
+    [
+      "Refresh balance outputs",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => x,
+      Matcher.Get,
+      () => balanceOutputs
+    ],
+    [
+      "Wait 1 min for deposit to be unlocked & issue a random tx to trigger a block built",
+      () => pChain.createSubnet(user2, passwd2, [P(addrB)], 1),
+      (x) => {
+        return x
+      },
+      Matcher.Get,
+      () => createdSubnetID,
+      60000 + 1000 // presale1min has a 1 minute unlock period +1 second
+    ],
+    [
+      "Verify deposited/depositedBonded amounts have decreased by the amount of the deposit",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) =>
+        sumAllValues(x.depositedOutputs)
+          .add(sumAllValues(x.bondedDepositedOutputs))
+          .toNumber(),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["depositedOutputs"])
+          .add(sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]))
+          .sub(getOneMinuteDepositOffer().minAmount)
+          .toNumber(),
+      3000
+    ],
+    [
+      "Refresh balance outputs",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => x,
+      Matcher.Get,
+      () => balanceOutputs
+    ],
+    [
+      "Issue a claimTx",
+      () =>
+        (async function () {
+          const claimableSigners: [number, Buffer][] = [[0, pAddresses[1]]]
 
-function getFirstDepositOfferWithFlag(
-  depositOffers: DepositOffer[],
-  flag: number
-): DepositOffer {
-  return depositOffers.find((depositOffer) =>
-    depositOffer.flags.eq(new BN(flag, 10))
-  )
+          const unsignedTx: UnsignedTx = await pChain.buildClaimTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            undefined,
+            ZeroBN,
+            1,
+            [],
+            ["HmxunfrZ4ar9jfBzu4PbwPAjukGZmeWGWgSEmnyFt8VFfPir1"], // hard-coded ownerID
+            [oneMinRewardsAmount],
+            new OutputOwners([pAddresses[1]]),
+            claimableSigners
+          )
+          const claimTx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(claimTx)
+        })(),
+      (x) => x,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "Verify tx has been committed",
+      () => pChain.getTxStatus(tx.value),
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "Verify deposited/depositedBonded amounts have increased by rewards amount (minus tx fee)",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => sumAllValues(x.unlockedOutputs),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["unlockedOutputs"])
+          .add(oneMinRewardsAmount)
+          .sub(avalanche.PChain().getTxFee())
+    ]
+  ]
+  createTests(tests_spec)
+})
+describe("Camino-PChain-Auto-Unlock-Deposit-Half-Amount", (): void => {
+  const tests_spec: any = [
+    [
+      "Get balance outputs",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => x,
+      Matcher.Get,
+      () => balanceOutputs
+    ],
+    [
+      "Issue depositTx -> presale1min",
+      () =>
+        (async function () {
+          const activeOffer: DepositOffer = getOneMinuteDepositOffer()
+          const unsignedTx: UnsignedTx = await pChain.buildDepositTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)],
+            activeOffer.id,
+            activeOffer.minDuration,
+            new OutputOwners([pAddresses[1]]),
+            memo,
+            new BN(0),
+            activeOffer.minAmount
+          )
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.Get,
+      () => depositTx
+    ],
+    [
+      "Verify tx has been committed",
+      () => {
+        return pChain.getTxStatus(depositTx.value)
+      },
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "Verify deposited/depositedBonded amounts have increased by the deposited amount",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) =>
+        sumAllValues(x.depositedOutputs).add(
+          sumAllValues(x.bondedDepositedOutputs)
+        ),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["depositedOutputs"]).add(
+          sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]).add(
+            getOneMinuteDepositOffer().minAmount
+          )
+        )
+    ],
+    [
+      "Refresh balance outputs",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => x,
+      Matcher.Get,
+      () => balanceOutputs
+    ],
+    [
+      "Wait 75% of unlock duration and issue an unlockDepositTx to manually unlock deposit",
+      () =>
+        (async function () {
+          const unsignedTx: UnsignedTx = await pChain.buildUnlockDepositTx(
+            undefined,
+            [P(addrB)],
+            [P(addrB)]
+          )
+          const tx: Tx = unsignedTx.sign(pKeychain)
+          return pChain.issueTx(tx)
+        })(),
+      (x) => x,
+      Matcher.Get,
+      () => tx,
+      45000 // 75% * unlock period
+    ],
+    [
+      "Verify tx has been committed",
+      () => pChain.getTxStatus(tx.value),
+      (x) => x.status,
+      Matcher.toBe,
+      () => "Committed",
+      3000
+    ],
+    [
+      "Verify deposited/depositedBonded amounts have decreased by 50%",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) =>
+        sumAllValues(x.depositedOutputs).add(
+          sumAllValues(x.bondedDepositedOutputs)
+        ),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["depositedOutputs"]).add(
+          sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]).sub(
+            getOneMinuteDepositOffer().minAmount.mul(
+              new BN(0.5) // 50% of deposit amount
+            )
+          )
+        )
+    ],
+    [
+      "Verify unlocked amounts haven been appropriately increased by 50% of the locked amount",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) => sumAllValues(x.unlockedOutputs),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["unlockedOutputs"])
+          .add(
+            getOneMinuteDepositOffer().minAmount.mul(
+              new BN(0.5) // 50% of deposit amount
+            )
+          )
+          .sub(avalanche.PChain().getTxFee())
+    ],
+    [
+      "Wait unlock duration and & issue a random tx to trigger build block",
+      () => pChain.createSubnet(user2, passwd2, [P(addrB)], 1),
+      (x) => {
+        return x
+      },
+      Matcher.Get,
+      () => createdSubnetID,
+      16000 // 25% * unlock period + 1s
+    ],
+    [
+      "Verify deposited/depositedBonded amounts haven been appropriately decreased by 100%",
+      () => pChain.getBalance({ address: P(addrB) }),
+      (x) =>
+        sumAllValues(x.depositedOutputs).add(
+          sumAllValues(x.bondedDepositedOutputs)
+        ),
+      Matcher.toEqual,
+      () =>
+        sumAllValues(balanceOutputs.value["depositedOutputs"]).add(
+          sumAllValues(balanceOutputs.value["bondedDepositedOutputs"]).sub(
+            getOneMinuteDepositOffer().minAmount
+          )
+        ),
+      3000
+    ]
+  ]
+  createTests(tests_spec)
+})
+
+function getOneMinuteDepositOffer(): DepositOffer {
+  return depositOffers.find((offer) => {
+    return offer.memo == "presale1min"
+  })
+}
+function getLockedPresale3yDepositOffer(): DepositOffer {
+  return depositOffers.find((offer) => {
+    return offer.memo == "lockedpresale3y"
+  })
+}
+function getTest1DepositOffer(): DepositOffer {
+  return depositOffers.find((offer) => {
+    return offer.memo.includes("depositOffer test#1")
+  })
 }

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -613,7 +613,7 @@ export class PlatformVMAPI extends JRPCAPI {
         maxDuration: offer.maxDuration,
         unlockPeriodDuration: offer.unlockPeriodDuration,
         noRewardsPeriodDuration: offer.noRewardsPeriodDuration,
-        memo: offer.memo,
+        memo: Buffer.from(offer.memo.substring(2), "hex").toString(),
         flags: new BN(offer.flags)
       } as DepositOffer
     })
@@ -2371,6 +2371,7 @@ export class PlatformVMAPI extends JRPCAPI {
     changeAddresses: string[] = undefined,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
+    amountToLock: BN,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     const caller = "buildUnlockDepositTx"
@@ -2408,6 +2409,78 @@ export class PlatformVMAPI extends JRPCAPI {
     }
 
     return builtUnsignedTx
+  }
+
+  /**
+   * Build an unsigned [[ClaimTx]].
+   *
+   * @param utxoset A set of UTXOs that the transaction is built on
+   * @param fromAddresses The addresses being used to send the funds from the UTXOs {@link https://github.com/feross/buffer|Buffer}
+   * @param changeAddresses The addresses that can spend the change remaining from the spent UTXOs.
+   * @param memo Optional contains arbitrary bytes, up to 256 bytes
+   * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
+   * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
+   * @param depositTxs The deposit transactions with which the claiblable rewards are associated
+   * @param claimableOwnerIDs The ownerIDs of the rewards to claim
+   * @param claimedAmounts The amounts of the rewards to claim
+   * @param claimTo The address to claimed rewards will be directed to
+   * @param claimableSigners The signers of the claimable rewards
+   *
+   * @returns An unsigned transaction created from the passed in parameters.
+   */
+  buildClaimTx = async (
+    utxoset: UTXOSet,
+    fromAddresses: string[],
+    changeAddresses: string[] = undefined,
+    memo: PayloadBase | Buffer = undefined,
+    asOf: BN = ZeroBN,
+    changeThreshold: number = 1,
+    depositTxs: string[] | Buffer[],
+    claimableOwnerIDs: string[] | Buffer[],
+    claimedAmounts: BN[],
+    claimTo: OutputOwners,
+    claimableSigners: [number, Buffer][] = []
+  ): Promise<UnsignedTx> => {
+    const caller = "buildClaimTx"
+    const fromSigner = this._parseFromSigner(fromAddresses, caller)
+    const change: Buffer[] = this._cleanAddressArrayBuffer(
+      changeAddresses,
+      caller
+    )
+    if (memo instanceof PayloadBase) {
+      memo = memo.getPayload()
+    }
+
+    const avaxAssetID: Buffer = await this.getAVAXAssetID()
+    const networkID: number = this.core.getNetworkID()
+    const blockchainID: Buffer = bintools.cb58Decode(this.blockchainID)
+    const fee: BN = this.getTxFee()
+
+    const unsignedClaimTx: UnsignedTx = await this._getBuilder(
+      utxoset
+    ).buildClaimTx(
+      networkID,
+      blockchainID,
+      fromSigner,
+      change,
+      fee,
+      avaxAssetID,
+      memo,
+      asOf,
+      changeThreshold,
+      depositTxs,
+      claimableOwnerIDs,
+      claimedAmounts,
+      claimTo,
+      claimableSigners
+    )
+
+    if (!(await this.checkGooseEgg(unsignedClaimTx, this.getCreationTxFee()))) {
+      /* istanbul ignore next */
+      throw new GooseEggCheckError("Failed Goose Egg Check")
+    }
+
+    return unsignedClaimTx
   }
 
   /**

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -613,7 +613,7 @@ export class PlatformVMAPI extends JRPCAPI {
         maxDuration: offer.maxDuration,
         unlockPeriodDuration: offer.unlockPeriodDuration,
         noRewardsPeriodDuration: offer.noRewardsPeriodDuration,
-        memo: Buffer.from(offer.memo.substring(2), "hex").toString(),
+        memo: offer.memo,
         flags: new BN(offer.flags)
       } as DepositOffer
     })

--- a/src/apis/platformvm/claimtx.ts
+++ b/src/apis/platformvm/claimtx.ts
@@ -1,0 +1,332 @@
+/**
+ * @packageDocumentation
+ * @module API-PlatformVM-ClaimTx
+ */
+import { Buffer } from "buffer/"
+import BinTools from "../../utils/bintools"
+import { PlatformVMConstants } from "./constants"
+import { ParseableOutput, TransferableOutput } from "./outputs"
+import { TransferableInput } from "./inputs"
+import { BaseTx } from "./basetx"
+import { DefaultNetworkID } from "../../utils/constants"
+import { Serialization, SerializedEncoding } from "../../utils/serialization"
+import BN from "bn.js"
+import { Credential, SigIdx, Signature } from "../../common"
+import { KeyChain, KeyPair } from "caminojs/apis/platformvm/keychain"
+import { SelectCredentialClass } from "./credentials"
+
+/**
+ * @ignore
+ */
+const bintools: BinTools = BinTools.getInstance()
+const serialization: Serialization = Serialization.getInstance()
+
+/**
+ * Class representing an unsigned ClaimTx transaction.
+ */
+export class ClaimTx extends BaseTx {
+  protected _typeName = "ClaimTx"
+  protected _typeID = PlatformVMConstants.CLAIMTX
+
+  deserialize(fields: object, encoding: SerializedEncoding = "hex") {
+    super.deserialize(fields, encoding)
+
+    this.depositTxs = fields["depositTxs"].map((txID: string) =>
+      serialization.decoder(txID, encoding, "cb58", "Buffer")
+    )
+    this.claimableOwnerIDs = fields["claimableOwnerIDs"].map(
+      (ownerID: string) =>
+        serialization.decoder(ownerID, encoding, "cb58", "Buffer")
+    )
+    this.claimedAmounts = fields["claimedAmounts"].map((amount: string) =>
+      serialization.decoder(amount, encoding, "decimalString", "Buffer")
+    )
+    this.claimTo.deserialize(fields["claimTo"], encoding)
+
+    // initialize other num fields
+    this.numDepositTxs = Buffer.alloc(4)
+    this.numDepositTxs.writeUInt32BE(this.numDepositTxs.length, 0)
+    this.numClaimableOwnerIDs = Buffer.alloc(4)
+    this.numClaimableOwnerIDs.writeUInt32BE(this.numClaimableOwnerIDs.length, 0)
+    this.numClaimedAmounts = Buffer.alloc(8)
+    this.numClaimedAmounts.writeUIntBE(this.numClaimedAmounts.length, 0, 8)
+  }
+
+  serialize(encoding: SerializedEncoding = "hex"): object {
+    let fields: object = super.serialize(encoding)
+    return {
+      ...fields,
+      depositTxs: this.depositTxs.map((txID) =>
+        serialization.encoder(txID, encoding, "Buffer", "cb58")
+      ),
+      claimableOwnerIDs: this.claimableOwnerIDs.map((ownerID) =>
+        serialization.encoder(ownerID, encoding, "Buffer", "cb58")
+      ),
+      claimedAmounts: this.claimedAmounts.map((amount) =>
+        serialization.encoder(amount, encoding, "Buffer", "decimalString")
+      ),
+      claimTo: this.claimTo.serialize(encoding)
+    }
+  }
+
+  protected numDepositTxs: Buffer = Buffer.alloc(4)
+  protected depositTxs: Buffer[] = []
+
+  protected numClaimableOwnerIDs: Buffer = Buffer.alloc(4)
+  protected claimableOwnerIDs: Buffer[] = []
+
+  protected numClaimedAmounts: Buffer = Buffer.alloc(4)
+  protected claimedAmounts: Buffer[] = []
+
+  // Deposit rewards outputs will be minted to this owner, unless all of its fields has zero-values.
+  // If it is empty, deposit rewards will be minted for depositTx.RewardsOwner.
+  protected claimTo: ParseableOutput = undefined
+  protected sigCount: Buffer = Buffer.alloc(4)
+  protected sigIdxs: SigIdx[] = [] // idxs of claimableIn signers
+
+  /**
+   * Returns the id of the [[RegisterNodeTx]]
+   */
+  getTxType(): number {
+    return this._typeID
+  }
+
+  /**
+   * Returns the array of claimed owner ids
+   */
+  getClaimableOwnerIDs(): Buffer[] {
+    return this.claimableOwnerIDs
+  }
+
+  /**
+   * Returns the array of claimed amounts
+   */
+  getClaimedAmounts(): Buffer[] {
+    return this.claimedAmounts
+  }
+  /**
+   * Returns the array of deposit tx ids
+   */
+  getDepositTxs(): Buffer[] {
+    return this.depositTxs
+  }
+
+  /**
+   * Returns the claimTo
+   */
+  getClaimTo(): ParseableOutput {
+    return this.claimTo
+  }
+
+  /**
+   * Takes a {@link https://github.com/feross/buffer|Buffer} containing a [[ClaimTx]], parses it, populates the class, and returns the length of the [[ClaimTx]] in bytes.
+   *
+   * @param bytes A {@link https://github.com/feross/buffer|Buffer} containing a raw [[ClaimTx]]
+   *
+   * @returns The length of the raw [[ClaimTx]]
+   *
+   * @remarks assume not-checksummed
+   */
+  fromBuffer(bytes: Buffer, offset: number = 0): number {
+    offset = super.fromBuffer(bytes, offset)
+
+    this.numDepositTxs = bintools.copyFrom(bytes, offset, offset + 4)
+    offset += 4
+    const txCount: number = this.numDepositTxs.readUInt32BE(0)
+    this.depositTxs = []
+    for (let i: number = 0; i < txCount; i++) {
+      const txid: Buffer = bintools.copyFrom(bytes, offset, offset + 32)
+      offset += 32
+      this.depositTxs.push(txid)
+    }
+
+    this.numClaimableOwnerIDs = bintools.copyFrom(bytes, offset, offset + 4)
+    offset += 4
+    const ownerCount: number = this.numClaimableOwnerIDs.readUInt32BE(0)
+    this.claimableOwnerIDs = []
+    for (let i: number = 0; i < ownerCount; i++) {
+      const ownerid: Buffer = bintools.copyFrom(bytes, offset, offset + 32)
+      offset += 32
+      this.claimableOwnerIDs.push(ownerid)
+    }
+
+    this.numClaimedAmounts = bintools.copyFrom(bytes, offset, offset + 4)
+    offset += 4
+    const amountCount: number = this.numClaimedAmounts.readUInt32BE(0)
+    this.claimedAmounts = []
+    for (let i: number = 0; i < amountCount; i++) {
+      const amount: Buffer = bintools.copyFrom(bytes, offset, offset + 8)
+      offset += 8
+      this.claimedAmounts.push(amount)
+    }
+
+    offset += 4
+    offset = this.claimTo.fromBuffer(bytes, offset)
+
+    return offset
+  }
+
+  /**
+   * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[ClaimTx]].
+   */
+  toBuffer(): Buffer {
+    const superbuff: Buffer = super.toBuffer()
+
+    let bsize: number = superbuff.length
+    const barr: Buffer[] = [superbuff]
+
+    barr.push(this.numDepositTxs)
+    bsize += this.numDepositTxs.length
+
+    this.depositTxs.forEach((depositTx: Buffer): void => {
+      bsize += depositTx.length
+      barr.push(depositTx)
+    })
+    barr.push(this.numClaimableOwnerIDs)
+    bsize += this.numClaimableOwnerIDs.length
+    this.claimableOwnerIDs.forEach((claimableOwnerID: Buffer): void => {
+      barr.push(claimableOwnerID)
+      bsize += claimableOwnerID.length
+    })
+
+    barr.push(this.numClaimedAmounts)
+    bsize += this.numClaimedAmounts.length
+    this.claimedAmounts.forEach((claimedAmount: Buffer): void => {
+      barr.push(claimedAmount)
+      bsize += claimedAmount.length
+    })
+
+    barr.push(this.claimTo.toBuffer())
+    bsize += this.claimTo.toBuffer().length
+
+    return Buffer.concat(barr, bsize)
+  }
+
+  clone(): this {
+    const newClaimTx: ClaimTx = new ClaimTx()
+    newClaimTx.fromBuffer(this.toBuffer())
+    return newClaimTx as this
+  }
+
+  create(...args: any[]): this {
+    return new ClaimTx(...args) as this
+  }
+
+  /**
+   * Creates and adds a [[SigIdx]] to the [[ClaimTx]].
+   *
+   * @param addressIdx The index of the address to reference in the signatures
+   * @param address The address of the source of the signature
+   */
+  addSignatureIdx(addressIdx: number, address: Buffer): void {
+    const sigidx: SigIdx = new SigIdx()
+    const b: Buffer = Buffer.alloc(4)
+    b.writeUInt32BE(addressIdx, 0)
+    sigidx.fromBuffer(b)
+    sigidx.setSource(address)
+    this.sigIdxs.push(sigidx)
+    this.sigCount.writeUInt32BE(this.sigIdxs.length, 0)
+  }
+
+  /**
+   * Returns the array of [[SigIdx]] for this [[TX]]
+   */
+  getSigIdxs(): SigIdx[] {
+    return this.sigIdxs
+  }
+
+  /**
+   * Set the array of [[SigIdx]] for this [[TX]]
+   */
+  setSigIdxs(sigIdxs: SigIdx[]) {
+    this.sigIdxs = sigIdxs
+    this.sigCount.writeUInt32BE(this.sigIdxs.length, 0)
+  }
+  /**
+   * Class representing an unsigned RegisterNode transaction.
+   *
+   * @param networkID Optional networkID, [[DefaultNetworkID]]
+   * @param blockchainID Optional blockchainID, default Buffer.alloc(32, 16)
+   * @param outs Optional array of the [[TransferableOutput]]s
+   * @param ins Optional array of the [[TransferableInput]]s
+   * @param depositTxs Optional array of the deposit txids
+   * @param claimableOwnerIDs Optional array of the claimable owner ids
+   * @param claimedAmounts Optional array of the claimed amounts
+   * @param claimTo Optional the owner of the rewards
+   */
+  constructor(
+    networkID: number = DefaultNetworkID,
+    blockchainID: Buffer = Buffer.alloc(32, 16),
+    outs: TransferableOutput[] = undefined,
+    ins: TransferableInput[] = undefined,
+    memo: Buffer = undefined,
+    depositTxs: string[] | Buffer[] = undefined,
+    claimableOwnerIDs: string[] | Buffer[] = undefined,
+    claimedAmounts: BN[] = undefined,
+    claimTo: ParseableOutput = undefined
+  ) {
+    super(networkID, blockchainID, outs, ins, memo)
+
+    if (typeof depositTxs != "undefined") {
+      this.numDepositTxs.writeUInt32BE(depositTxs.length, 0)
+      const depositTxBufs: Buffer[] = []
+      depositTxs.forEach((txID: string | Buffer): void => {
+        if (typeof txID === "string") {
+          depositTxBufs.push(bintools.cb58Decode(txID))
+        } else {
+          depositTxBufs.push(txID)
+        }
+      })
+      this.depositTxs = depositTxBufs
+    }
+
+    if (typeof claimableOwnerIDs != "undefined") {
+      this.numClaimableOwnerIDs.writeUInt32BE(claimableOwnerIDs.length, 0)
+      const claimableOwnerIDBufs: Buffer[] = []
+      claimableOwnerIDs.forEach((ownerID: string | Buffer): void => {
+        if (typeof ownerID === "string") {
+          claimableOwnerIDBufs.push(bintools.cb58Decode(ownerID))
+        } else {
+          claimableOwnerIDBufs.push(ownerID)
+        }
+      })
+      this.claimableOwnerIDs = claimableOwnerIDBufs
+    }
+
+    if (typeof claimedAmounts != "undefined") {
+      this.numClaimedAmounts.writeUInt32BE(claimedAmounts.length, 0)
+      const claimedAmountBufs: Buffer[] = []
+      claimedAmounts.forEach((amount: BN): void => {
+        claimedAmountBufs.push(bintools.fromBNToBuffer(amount, 8))
+      })
+      this.claimedAmounts = claimedAmountBufs
+    }
+
+    this.claimTo = claimTo
+  }
+
+  /**
+   * Takes the bytes of an [[UnsignedTx]] and returns an array of [[Credential]]s
+   *
+   * @param msg A Buffer for the [[UnsignedTx]]
+   * @param kc An [[KeyChain]] used in signing
+   *
+   * @returns An array of [[Credential]]s
+   */
+  sign(msg: Buffer, kc: KeyChain): Credential[] {
+    const creds: Credential[] = super.sign(msg, kc)
+    const sigidxs: SigIdx[] = this.getSigIdxs()
+    const cred: Credential = SelectCredentialClass(
+      PlatformVMConstants.SECPCREDENTIAL
+    )
+    for (let i: number = 0; i < sigidxs.length; i++) {
+      const keypair: KeyPair = kc.getKey(sigidxs[`${i}`].getSource())
+      const signval: Buffer = keypair.sign(msg)
+      const sig: Signature = new Signature()
+      sig.fromBuffer(signval)
+      cred.addSignature(sig)
+    }
+    creds.push(cred)
+    return creds
+  }
+}


### PR DESCRIPTION
## Why this should be merged
Introduces new e2e tests for the P-Chain which relate to the deposit and unlock deposit functionality. More specifically, it tests both the automatic as well as the combination of manual and auto unlock of deposited funds.

## How this works
By issuing deposit and unlockDeposit txs as well as by checking affected balances after waiting for the necessary deposit duration.

## How this was tested
See committed e2e tests.

Note: This PR requires the merge of https://github.com/chain4travel/camino-network-runner/pull/32 to run green