### PR TITLE
[PVM] Updated GetDepositsResponse and related api

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -620,13 +620,15 @@ export class PlatformVMAPI extends JRPCAPI {
   }
 
   /**
-   * Returns deposits coressponding to requested txIDs.
+   * Returns deposits corresponding to requested txIDs.
    *
    * @param depositTxIDs A list of txIDs (cb58) to request deposits for.
    *
-   * @returns Promise for a list containing deposits.
+   * @returns Promise for a GetDepositsResponse object.
    */
-  getDeposits = async (depositTxIDs: string[]): Promise<APIDeposit[]> => {
+  getDeposits = async (
+    depositTxIDs: string[]
+  ): Promise<GetDepositsResponse> => {
     const params: GetDepositsParams = {
       depositTxIDs
     }
@@ -636,17 +638,21 @@ export class PlatformVMAPI extends JRPCAPI {
     )
 
     const deposits: GetDepositsResponse = response.data.result
-    return deposits.deposits.map((deposit) => {
-      return {
-        depositTxID: deposit.depositTxID,
-        depositOfferID: deposit.depositOfferID,
-        unlockedAmount: new BN(deposit.unlockedAmount),
-        claimedRewardAmount: new BN(deposit.claimedRewardAmount),
-        start: new BN(deposit.start),
-        duration: deposit.duration,
-        amount: new BN(deposit.amount)
-      } as APIDeposit
-    })
+    return {
+      deposits: deposits.deposits.map((deposit) => {
+        return {
+          depositTxID: deposit.depositTxID,
+          depositOfferID: deposit.depositOfferID,
+          unlockedAmount: new BN(deposit.unlockedAmount),
+          claimedRewardAmount: new BN(deposit.claimedRewardAmount),
+          start: new BN(deposit.start),
+          duration: deposit.duration,
+          amount: new BN(deposit.amount)
+        } as APIDeposit
+      }),
+      availableRewards: deposits.availableRewards.map((a) => new BN(a)),
+      timestamp: new BN(deposits.timestamp)
+    } as GetDepositsResponse
   }
 
   /**

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -280,6 +280,8 @@ export interface GetDepositsParams {
 
 export interface GetDepositsResponse {
   deposits: APIDeposit[]
+  availableRewards: BN[]
+  timestamp: BN
 }
 
 export interface APIDeposit {


### PR DESCRIPTION
## Why this should be merged
Updates the getBalances api and its returned response so that it contains the newly introduced fields `availableRewards` and `timestamp`

## How this works
It extends the interface GetDepositsResponse and refactors the getDeposits function in api.ts (of pvm) to return all fields.

## How this was tested
Manually by spinning up a local network adding deposits and then calling the example _examples/platformvm/getDeposits.ts_
which printed out the following json:
```
{
  deposits: [
    {
      depositTxID: '8RzKzxVhQofzGSWxxDhdQouUGy62UCekrpu6FrXoS6gydXZwU',
      depositOfferID: '2YKmgZ4FbeBMsJTAd4C9g6Y7sYGX5z6PxQHRK99BQ8xvmHwv9S',
      unlockedAmount: <BN: 0>,
      claimedRewardAmount: <BN: 0>,
      start: <BN: 64258cb4>,
      duration: 31536000,
      amount: <BN: 1>
    },
    {
      depositTxID: '2WteM3d5NH2i4x6QzUpGodYzZRXwCXgNnzkg1Hixw48iAeRbSE',
      depositOfferID: '2YKmgZ4FbeBMsJTAd4C9g6Y7sYGX5z6PxQHRK99BQ8xvmHwv9S',
      unlockedAmount: <BN: 0>,
      claimedRewardAmount: <BN: 0>,
      start: <BN: 64258be3>,
      duration: 31536000,
      amount: <BN: 1>
    }
  ],
  availableRewards: [ <BN: 0>, <BN: 0> ],
  timestamp: <BN: 64258e31>
}
```