### PR TITLE
[PVM] Updated claimtx to include claimType

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -603,6 +603,7 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
             ["HmxunfrZ4ar9jfBzu4PbwPAjukGZmeWGWgSEmnyFt8VFfPir1"], // hard-coded ownerID
             [oneMinRewardsAmount],
             new OutputOwners([pAddresses[1]]),
+            new BN(2), // ClaimTypeExpiredDepositReward
             claimableSigners
           )
           const claimTx: Tx = unsignedTx.sign(pKeychain)

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -2430,6 +2430,7 @@ export class PlatformVMAPI extends JRPCAPI {
    * @param claimableOwnerIDs The ownerIDs of the rewards to claim
    * @param claimedAmounts The amounts of the rewards to claim
    * @param claimTo The address to claimed rewards will be directed to
+   * @param claimType The type of claim tx
    * @param claimableSigners The signers of the claimable rewards
    *
    * @returns An unsigned transaction created from the passed in parameters.
@@ -2445,6 +2446,7 @@ export class PlatformVMAPI extends JRPCAPI {
     claimableOwnerIDs: string[] | Buffer[],
     claimedAmounts: BN[],
     claimTo: OutputOwners,
+    claimType: BN,
     claimableSigners: [number, Buffer][] = []
   ): Promise<UnsignedTx> => {
     const caller = "buildClaimTx"
@@ -2478,6 +2480,7 @@ export class PlatformVMAPI extends JRPCAPI {
       claimableOwnerIDs,
       claimedAmounts,
       claimTo,
+      claimType,
       claimableSigners
     )
 

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1438,6 +1438,7 @@ export class Builder {
    * @param depositTxs The deposit transactions with which the claiblable rewards are associated
    * @param claimableOwnerIDs The ownerIDs of the rewards to claim
    * @param claimedAmounts The amounts of the rewards to claim
+   * @param claimType The type of claim tx
    * @param claimTo The address to claimed rewards will be directed to
    *
    * @returns An unsigned ClaimTx created from the passed in parameters.
@@ -1456,6 +1457,7 @@ export class Builder {
     claimableOwnerIDs: string[] | Buffer[],
     claimedAmounts: BN[],
     claimTo: OutputOwners,
+    claimType: BN,
     claimableSigners: [number, Buffer][] = []
   ): Promise<UnsignedTx> => {
     let ins: TransferableInput[] = []
@@ -1503,6 +1505,7 @@ export class Builder {
       depositTxs,
       claimableOwnerIDs,
       claimedAmounts,
+      claimType,
       new ParseableOutput(secpOwners)
     )
     claimableSigners.forEach((signer: [number, Buffer]) => {


### PR DESCRIPTION
## Why this should be merged
A new field (`claimType`) has been introduced in the claimTx of caminogo. Thus, the corresponding API using/building this tx has to be adjusted accordingly.

## How this works
Updates the API for building a claimTx by introducing the new field `claimType`.

## How this was tested
See updated e2e tests.