### PR TITLE
[PVM] Removed redundant parameter from API getClaimables

### DIFF
--- a/examples/platformvm/getClaimables.ts
+++ b/examples/platformvm/getClaimables.ts
@@ -31,11 +31,8 @@ const InitAvalanche = async () => {
 
 const main = async (): Promise<any> => {
   await InitAvalanche()
-
-  const txIDs: string[] = []
   const claimables: GetClaimablesResponse = await pchain.getClaimables(
-    pAddressStrings,
-    txIDs
+    pAddressStrings
   )
   console.log(claimables)
 }

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -72,12 +72,12 @@ import {
   SpendReply,
   AddressParams,
   MultisigAliasReply,
-  GetClaimablesParams,
   GetClaimablesResponse,
   GetAllDepositOffersParams,
   GetAllDepositOffersResponse,
   GetDepositsParams,
-  GetDepositsResponse
+  GetDepositsResponse,
+  Owner
 } from "./interfaces"
 import { TransferableInput } from "./inputs"
 import { TransferableOutput } from "./outputs"
@@ -659,7 +659,6 @@ export class PlatformVMAPI extends JRPCAPI {
    * List amounts that can be claimed: validator rewards, expired deposit rewards, active deposit rewards claimable at current time.
    *
    * @param addresses An array of addresses as cb58 strings or addresses as {@link https://github.com/feross/buffer|Buffer}s
-   * @param depositTxIDs An array of deposit transactions ids
    * @param locktime Optional. The locktime field created in the resulting outputs
    * @param threshold Optional. The number of signatures required to spend the funds in the resultant UTXO
    *
@@ -667,17 +666,13 @@ export class PlatformVMAPI extends JRPCAPI {
    */
   getClaimables = async (
     addresses: string[],
-    depositTxIDs: string[],
     locktime: string = undefined,
     threshold: number = 1
   ): Promise<GetClaimablesResponse> => {
-    const params: GetClaimablesParams = {
+    const params: Owner = {
+      locktime,
       threshold,
-      addresses,
-      depositTxIDs
-    }
-    if (typeof locktime !== "undefined") {
-      params.locktime = locktime
+      addresses
     }
     const response: RequestResponseData = await this.callMethod(
       "platform.getClaimables",

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -67,13 +67,6 @@ export interface GetCurrentValidatorsParams {
   nodeIDs?: string[]
 }
 
-export interface GetClaimablesParams {
-  addresses: string[]
-  depositTxIDs: string[]
-  locktime?: string
-  threshold: number
-}
-
 export interface GetAllDepositOffersParams {
   active: boolean
 }


### PR DESCRIPTION
## Why this should be merged
The API getClaimables should be callable without providing any depositTxIds. The only required parameters are those of an interface `Owner` where locktime and threshold are optional as the are assigned defualt values if none are provided.

## How this works
Updates the API by removing the redundant field depositTxIds. Since that renders the `GetClaimablesParams` identical to the `Owner` interface, the former has been completely removed.

## How this was tested
By  running the corresponding example and ensuring that the API returns a valid response