### PR TITLE
[PVM] Replaced claimableOwnersIDs with claimableOwners in API buildClaimTx

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -52,6 +52,7 @@ let createdSubnetID = { value: "" }
 let pAddressStrings: string[]
 let balanceOutputs = { value: new Map() }
 let oneMinRewardsAmount: BN
+let rewardsOwner: OutputOwners
 beforeAll(async () => {
   await avalanche.fetchNetworkSettings()
   keystore = new KeystoreAPI(avalanche)
@@ -78,6 +79,7 @@ beforeAll(async () => {
     )
     .mul(getOneMinuteDepositOffer().interestRateNominator)
     .div(interestRateDenominator)
+  rewardsOwner = new OutputOwners([pAddresses[1]])
 })
 
 describe("Camino-PChain-Add-Validator", (): void => {
@@ -404,7 +406,7 @@ describe("Camino-PChain-Deposit", (): void => {
             [P(addrB)],
             activeOffer.id,
             activeOffer.maxDuration,
-            new OutputOwners([pAddresses[1]]),
+            rewardsOwner,
             memo,
             new BN(0),
             activeOffer.minAmount
@@ -510,7 +512,7 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
             [P(addrB)],
             activeOffer.id,
             activeOffer.minDuration,
-            new OutputOwners([pAddresses[1]]),
+            rewardsOwner,
             memo,
             new BN(0),
             activeOffer.minAmount
@@ -591,7 +593,6 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
       () =>
         (async function () {
           const claimableSigners: [number, Buffer][] = [[0, pAddresses[1]]]
-
           const unsignedTx: UnsignedTx = await pChain.buildClaimTx(
             undefined,
             [P(addrB)],
@@ -600,9 +601,9 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
             ZeroBN,
             1,
             [],
-            ["HmxunfrZ4ar9jfBzu4PbwPAjukGZmeWGWgSEmnyFt8VFfPir1"], // hard-coded ownerID
+            [rewardsOwner],
             [oneMinRewardsAmount],
-            new OutputOwners([pAddresses[1]]),
+            rewardsOwner,
             new BN(2), // ClaimTypeExpiredDepositReward
             claimableSigners
           )
@@ -654,7 +655,7 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Half-Amount", (): void => {
             [P(addrB)],
             activeOffer.id,
             activeOffer.minDuration,
-            new OutputOwners([pAddresses[1]]),
+            rewardsOwner,
             memo,
             new BN(0),
             activeOffer.minAmount

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -86,6 +86,7 @@ import { GenesisData } from "../avm"
 import { Auth, LockMode, Builder, FromSigner } from "./builder"
 import { Network } from "../../utils/networks"
 import { Spender } from "./spender"
+import createHash from "create-hash"
 
 /**
  * @ignore
@@ -2426,9 +2427,9 @@ export class PlatformVMAPI extends JRPCAPI {
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
-   * @param depositTxs The deposit transactions with which the claiblable rewards are associated
-   * @param claimableOwnerIDs The ownerIDs of the rewards to claim
-   * @param claimedAmounts The amounts of the rewards to claim
+   * @param depositTxIDs Optional. The deposit transactions ids with which the claimable rewards are associated
+   * @param claimableOwners Optional. The owners of the rewards to claim
+   * @param claimedAmounts Optional. The amounts of the rewards to claim
    * @param claimTo The address to claimed rewards will be directed to
    * @param claimType The type of claim tx
    * @param claimableSigners The signers of the claimable rewards
@@ -2442,9 +2443,9 @@ export class PlatformVMAPI extends JRPCAPI {
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
     changeThreshold: number = 1,
-    depositTxs: string[] | Buffer[],
-    claimableOwnerIDs: string[] | Buffer[],
-    claimedAmounts: BN[],
+    depositTxIDs: string[] | Buffer[] = [],
+    claimableOwners: OutputOwners[] = [],
+    claimedAmounts: BN[] = [],
     claimTo: OutputOwners,
     claimType: BN,
     claimableSigners: [number, Buffer][] = []
@@ -2458,11 +2459,30 @@ export class PlatformVMAPI extends JRPCAPI {
     if (memo instanceof PayloadBase) {
       memo = memo.getPayload()
     }
+    if (depositTxIDs.length === 0 && claimableOwners.length === 0) {
+      throw new Error("Must provide at least one depositTxID or claimableOwner")
+    }
+    if (claimedAmounts.length !== claimableOwners.length) {
+      throw new Error("Must provide claimedAmounts for each claimableOwner")
+    }
 
     const avaxAssetID: Buffer = await this.getAVAXAssetID()
     const networkID: number = this.core.getNetworkID()
     const blockchainID: Buffer = bintools.cb58Decode(this.blockchainID)
     const fee: BN = this.getTxFee()
+
+    const claimableOwnerIDs: Buffer[] = []
+    // for each claimable owner, create a sha256 out of its bytes prefixed with the latest codecID
+    for (let i = 0; i < claimableOwners.length; i++) {
+      const b = Buffer.alloc(2, PlatformVMConstants.LATESTCODEC)
+      claimableOwnerIDs.push(
+        Buffer.from(
+          createHash("sha256")
+            .update(Buffer.concat([b, claimableOwners[i].toBuffer()]))
+            .digest()
+        )
+      )
+    }
 
     const unsignedClaimTx: UnsignedTx = await this._getBuilder(
       utxoset
@@ -2476,7 +2496,7 @@ export class PlatformVMAPI extends JRPCAPI {
       memo,
       asOf,
       changeThreshold,
-      depositTxs,
+      depositTxIDs,
       claimableOwnerIDs,
       claimedAmounts,
       claimTo,

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1435,7 +1435,7 @@ export class Builder {
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
-   * @param depositTxs The deposit transactions with which the claiblable rewards are associated
+   * @param depositTxIDs The deposit transactions ids with which the claiblable rewards are associated
    * @param claimableOwnerIDs The ownerIDs of the rewards to claim
    * @param claimedAmounts The amounts of the rewards to claim
    * @param claimType The type of claim tx
@@ -1453,7 +1453,7 @@ export class Builder {
     memo: Buffer = undefined,
     asOf: BN = zero,
     changeThreshold: number = 1,
-    depositTxs: string[] | Buffer[],
+    depositTxIDs: string[] | Buffer[],
     claimableOwnerIDs: string[] | Buffer[],
     claimedAmounts: BN[],
     claimTo: OutputOwners,
@@ -1502,7 +1502,7 @@ export class Builder {
       outs,
       ins,
       memo,
-      depositTxs,
+      depositTxIDs,
       claimableOwnerIDs,
       claimedAmounts,
       claimType,

--- a/src/apis/platformvm/claimtx.ts
+++ b/src/apis/platformvm/claimtx.ts
@@ -265,7 +265,7 @@ export class ClaimTx extends BaseTx {
    * @param blockchainID Optional blockchainID, default Buffer.alloc(32, 16)
    * @param outs Optional array of the [[TransferableOutput]]s
    * @param ins Optional array of the [[TransferableInput]]s
-   * @param depositTxs Optional array of the deposit txids
+   * @param depositTxIDs Optional array of the deposit tx ids
    * @param claimableOwnerIDs Optional array of the claimable owner ids
    * @param claimedAmounts Optional array of the claimed amounts
    * @param claimType Optional the type of the claim
@@ -277,7 +277,7 @@ export class ClaimTx extends BaseTx {
     outs: TransferableOutput[] = undefined,
     ins: TransferableInput[] = undefined,
     memo: Buffer = undefined,
-    depositTxs: string[] | Buffer[] = undefined,
+    depositTxIDs: string[] | Buffer[] = undefined,
     claimableOwnerIDs: string[] | Buffer[] = undefined,
     claimedAmounts: BN[] = undefined,
     claimType: BN = undefined,
@@ -285,10 +285,10 @@ export class ClaimTx extends BaseTx {
   ) {
     super(networkID, blockchainID, outs, ins, memo)
 
-    if (typeof depositTxs != "undefined") {
-      this.numDepositTxs.writeUInt32BE(depositTxs.length, 0)
+    if (typeof depositTxIDs != "undefined") {
+      this.numDepositTxs.writeUInt32BE(depositTxIDs.length, 0)
       const depositTxBufs: Buffer[] = []
-      depositTxs.forEach((txID: string | Buffer): void => {
+      depositTxIDs.forEach((txID: string | Buffer): void => {
         if (typeof txID === "string") {
           depositTxBufs.push(bintools.cb58Decode(txID))
         } else {


### PR DESCRIPTION
## Why this should be merged
The API buildClaimTx accepts at the moment a list of claimableOwnerIDs. These IDs have to be calculated (by generating a hash of the bytes of these owners) which makes the call of the api more complicated and less "user-friendly". The purpose of this PR is to move this logic inside the API so that the consumer can provide a list of claimableOwners instead (class: `OutputOwners`).

## How this works
The API accepts a list of `OutputOwners` instead of a list of IDs (`string[] | Buffer[]`), performs some sanity checks on the inputs and then calculates the IDs of the `OutputOwners` and passes the information further onto the corresponding builder function.

## How this was tested
By adjusting the corresponding e2e test and ensure that it passes the same checks.

Note: The PR also includes some minor refactorings (renamings of parameters).