### PR TITLE
[PVM] Added unit tests for addressStateTx, claimTx, depositTx

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../src/common"
 import { PChainAlias } from "../../src/utils"
 import createHash from "create-hash"
+import { ClaimType } from "../../src/apis/platformvm/claimtx"
 const bintools = BinTools.getInstance()
 
 const adminAddress = "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
@@ -638,7 +639,7 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
             [rewardsOwner],
             [oneMinRewardsAmount],
             rewardsOwner,
-            new BN(2), // ClaimTypeExpiredDepositReward
+            ClaimType.EXPIRED_DEPOSIT_REWARD,
             claimableSigners
           )
           const claimTx: Tx = unsignedTx.sign(pKeychain)

--- a/src/apis/platformvm/claimtx.ts
+++ b/src/apis/platformvm/claimtx.ts
@@ -21,6 +21,12 @@ import { SelectCredentialClass } from "./credentials"
 const bintools: BinTools = BinTools.getInstance()
 const serialization: Serialization = Serialization.getInstance()
 
+export const ClaimType = {
+  VALIDATOR_REWARD: new BN("1"),
+  EXPIRED_DEPOSIT_REWARD: new BN("2"),
+  ALL: new BN("3")
+} as const
+
 /**
  * Class representing an unsigned ClaimTx transaction.
  */
@@ -131,6 +137,10 @@ export class ClaimTx extends BaseTx {
     return this.claimTo
   }
 
+  getClaimType(): Buffer {
+    return this.claimType
+  }
+
   /**
    * Takes a {@link https://github.com/feross/buffer|Buffer} containing a [[ClaimTx]], parses it, populates the class, and returns the length of the [[ClaimTx]] in bytes.
    *
@@ -175,8 +185,8 @@ export class ClaimTx extends BaseTx {
 
     this.claimType = bintools.copyFrom(bytes, offset, offset + 8)
     offset += 8
+    this.claimTo = new ParseableOutput()
     offset = this.claimTo.fromBuffer(bytes, offset)
-
     return offset
   }
 

--- a/src/apis/platformvm/depositTx.ts
+++ b/src/apis/platformvm/depositTx.ts
@@ -112,6 +112,7 @@ export class DepositTx extends BaseTx {
     offset += 32
     this.depositDuration = bintools.copyFrom(bytes, offset, offset + 4)
     offset += 4
+    this.rewardsOwner = new ParseableOutput()
     offset = this.rewardsOwner.fromBuffer(bytes, offset)
 
     return offset
@@ -134,7 +135,7 @@ export class DepositTx extends BaseTx {
     ]
 
     barr.push(this.rewardsOwner.toBuffer())
-    bsize += barr[barr.length - 1].length
+    bsize += this.rewardsOwner.toBuffer().length
 
     return Buffer.concat(barr, bsize)
   }

--- a/src/apis/platformvm/registernodetx.ts
+++ b/src/apis/platformvm/registernodetx.ts
@@ -78,6 +78,17 @@ export class RegisterNodeTx extends BaseTx {
     return PlatformVMConstants.REGISTERNODETX
   }
 
+  getOldNodeID(): Buffer {
+    return this.oldNodeID
+  }
+
+  getNewNodeID(): Buffer {
+    return this.newNodeID
+  }
+  getConsortiumMemberAddress(): Buffer {
+    return this.consortiumMemberAddress
+  }
+
   /**
    * Returns the subnetAuth
    */

--- a/tests/apis/platformvm/addressstatetx.test.ts
+++ b/tests/apis/platformvm/addressstatetx.test.ts
@@ -1,0 +1,88 @@
+import BN from "bn.js"
+import { Buffer } from "buffer/"
+import { PlatformVMConstants } from "src/apis/platformvm"
+import {
+  ADDRESSSTATEKYCVERIFIED,
+  AddressStateTx
+} from "src/apis/platformvm/addressstatetx"
+import BinTools from "src/utils/bintools"
+import { DefaultNetworkID, Serialization } from "src/utils"
+
+const serialization: Serialization = Serialization.getInstance()
+const bintools: BinTools = BinTools.getInstance()
+
+describe("AddressStateTx", (): void => {
+  const addressStateTxHex: string =
+    "0000000110101010101010101010101010101010101010101010101010101010101010100000000000000000000000046d656d6f28ed371fef40e69e4e43138df31278d087fe46242001"
+  const addressStateTxBuf: Buffer = Buffer.from(addressStateTxHex, "hex")
+  const addressStateTx: AddressStateTx = new AddressStateTx()
+  addressStateTx.fromBuffer(addressStateTxBuf)
+
+  test("getTypeName", async (): Promise<void> => {
+    const addressStateTxTypeName: string = addressStateTx.getTypeName()
+    expect(addressStateTxTypeName).toBe("AddressStateTx")
+  })
+
+  test("getTypeID", async (): Promise<void> => {
+    const addressStateTxTypeID: number = addressStateTx.getTypeID()
+    expect(addressStateTxTypeID).toBe(PlatformVMConstants.ADDRESSSTATETX)
+  })
+
+  test("toBuffer and fromBuffer", async (): Promise<void> => {
+    const buf: Buffer = addressStateTx.toBuffer()
+    const asvTx: AddressStateTx = new AddressStateTx()
+    asvTx.fromBuffer(buf)
+    const buf2: Buffer = asvTx.toBuffer()
+    expect(buf.toString("hex")).toBe(buf2.toString("hex"))
+  })
+
+  test("serialize", async (): Promise<void> => {
+    const serializedAddressStateTx: object = addressStateTx.serialize()
+
+    const expectedJSON = {
+      _codecID: null,
+      _typeID: PlatformVMConstants.ADDRESSSTATETX,
+      _typeName: "AddressStateTx",
+      address: serialization
+        .typeToBuffer(
+          "X-local19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq",
+          "bech32"
+        )
+        .toString("hex"),
+      blockchainID: serialization.encoder(
+        Buffer.alloc(32, 16),
+        "hex",
+        "Buffer",
+        "cb58"
+      ),
+      ins: [],
+      memo: serialization
+        .typeToBuffer(bintools.cb58Encode(Buffer.from("memo")), "cb58")
+        .toString("hex"),
+      networkID: String(DefaultNetworkID).padStart(8, "0"),
+      outs: [],
+      state: ADDRESSSTATEKYCVERIFIED,
+      remove: true
+    }
+    expect(serializedAddressStateTx).toStrictEqual(expectedJSON)
+  })
+
+  test("getAddress", async (): Promise<void> => {
+    const expectedAddress: Buffer = bintools.stringToAddress(
+      "X-local19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq",
+      "local"
+    )
+    const address: Buffer = addressStateTx.getAddress()
+    expect(address.toString()).toBe(expectedAddress.toString())
+  })
+
+  test("getState", async (): Promise<void> => {
+    const expectedState = ADDRESSSTATEKYCVERIFIED
+    expect(addressStateTx.getState()).toBe(expectedState)
+  })
+
+  test("getRemove", async (): Promise<void> => {
+    const expectedRemove = true
+    expect(addressStateTx.getRemove()).toBe(expectedRemove)
+  })
+})

--- a/tests/apis/platformvm/claimtx.test.ts
+++ b/tests/apis/platformvm/claimtx.test.ts
@@ -1,0 +1,188 @@
+import BN from "bn.js"
+import { Buffer } from "buffer/"
+import {
+  KeyChain,
+  ParseableOutput,
+  PlatformVMAPI,
+  PlatformVMConstants,
+  SECPOwnerOutput,
+  SECPTransferInput,
+  SECPTransferOutput,
+  TransferableInput,
+  TransferableOutput
+} from "src/apis/platformvm"
+import { ClaimTx, ClaimType } from "src/apis/platformvm/claimtx"
+import BinTools from "src/utils/bintools"
+import {
+  DefaultLocalGenesisPrivateKey,
+  DefaultNetworkID,
+  PrivateKeyPrefix,
+  Serialization
+} from "src/utils"
+import createHash from "create-hash"
+import { SigIdx, ZeroBN } from "src/common"
+import Avalanche from "src/index"
+
+const avalanche: Avalanche = new Avalanche(
+  "127.0.0.1",
+  9650,
+  "https",
+  12345,
+  undefined,
+  undefined
+)
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+const serialization: Serialization = Serialization.getInstance()
+const bintools: BinTools = BinTools.getInstance()
+const ownerID: Buffer = Buffer.from(
+  createHash("sha256")
+    .update(bintools.fromBNToBuffer(new BN(2), 32))
+    .digest()
+)
+const depositTxID: Buffer = Buffer.from(
+  createHash("sha256")
+    .update(bintools.fromBNToBuffer(new BN(1), 32))
+    .digest()
+)
+const claimedAmount = new BN(1)
+let rewardOutputOwners: SECPOwnerOutput
+let platformVM: PlatformVMAPI
+let keychain: KeyChain
+let avaxAssetID: Buffer
+let secpTransferOutput: SECPTransferOutput
+let secpTransferInput: SECPTransferInput
+
+const removeJsonProperty = (obj, property) => {
+  let json = JSON.stringify(obj)
+  const regex = new RegExp(`,?"${property}":".*?",?`, "gi")
+  json = json.replace(regex, "")
+  json = json.replace(/""/, '","')
+  return JSON.parse(json)
+}
+
+beforeAll(async () => {
+  platformVM = new PlatformVMAPI(avalanche, "/ext/bc/P")
+  keychain = platformVM.keyChain()
+  keychain.importKey(privKey)
+
+  rewardOutputOwners = new SECPOwnerOutput(
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+  avaxAssetID = await platformVM.getAVAXAssetID()
+  secpTransferInput = new SECPTransferInput(new BN(1))
+  secpTransferInput.addSignatureIdx(0, keychain.getAddresses()[0])
+
+  secpTransferOutput = new SECPTransferOutput(
+    new BN(1),
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+})
+describe("ClaimTx", (): void => {
+  const claimTxHex: string =
+    "00000001101010101010101010101010101010101010101010101010101010101010101000000001dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db000000070000000000000001000000000000000000000001000000013cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000001ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc500000000dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db0000000500000000000000010000000100000000000000046d656d6f00000001ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5000000019267d3dbed802941483f1afa2a6bc68de5f653128aca9bf1461c5d0a3ad36ed200000001000000000000000100000000000000020000000b000000000000000000000001000000013cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c"
+  const claimTxBuf: Buffer = Buffer.from(claimTxHex, "hex")
+  const claimTx: ClaimTx = new ClaimTx()
+  claimTx.fromBuffer(claimTxBuf)
+
+  test("getTypeName", async (): Promise<void> => {
+    const claimTxTypeName: string = claimTx.getTypeName()
+    expect(claimTxTypeName).toBe("ClaimTx")
+  })
+
+  test("getTypeID", async (): Promise<void> => {
+    const claimTxTypeID: number = claimTx.getTypeID()
+    expect(claimTxTypeID).toBe(PlatformVMConstants.CLAIMTX)
+  })
+
+  test("toBuffer and fromBuffer", async (): Promise<void> => {
+    const buf: Buffer = claimTx.toBuffer()
+    const asvTx: ClaimTx = new ClaimTx()
+    asvTx.fromBuffer(buf)
+    const buf2: Buffer = asvTx.toBuffer()
+    expect(buf.toString("hex")).toBe(buf2.toString("hex"))
+  })
+
+  test("serialize", async (): Promise<void> => {
+    const serializedClaimTx: object = claimTx.serialize()
+
+    const expectedJSON = {
+      _codecID: null,
+      _typeID: PlatformVMConstants.CLAIMTX,
+      _typeName: "ClaimTx",
+      blockchainID: serialization.encoder(
+        Buffer.alloc(32, 16),
+        "hex",
+        "Buffer",
+        "cb58"
+      ),
+      outs: [
+        new TransferableOutput(avaxAssetID, secpTransferOutput).serialize()
+      ],
+      ins: [
+        new TransferableInput(
+          depositTxID,
+          Buffer.from(bintools.fromBNToBuffer(new BN(0), 4)),
+          avaxAssetID,
+          secpTransferInput
+        ).serialize()
+      ],
+      memo: serialization
+        .typeToBuffer(bintools.cb58Encode(Buffer.from("memo")), "cb58")
+        .toString("hex"),
+      networkID: String(DefaultNetworkID).padStart(8, "0"),
+      claimableOwnerIDs: [ownerID.toString("hex")],
+      claimedAmounts: [new BN(1).toString(10, 16)],
+      depositTxs: [depositTxID.toString("hex")],
+      claimType: ClaimType.EXPIRED_DEPOSIT_REWARD.toString(10, 16),
+      claimTo: new ParseableOutput(rewardOutputOwners).serialize()
+    }
+
+    expect(removeJsonProperty(serializedClaimTx, "source")).toStrictEqual(
+      removeJsonProperty(expectedJSON, "source")
+    )
+  })
+
+  test("getClaimableOwnerIDs", async (): Promise<void> => {
+    const actualClaimableOwnerIDs: Buffer[] = claimTx.getClaimableOwnerIDs()
+    expect(actualClaimableOwnerIDs).toStrictEqual([ownerID])
+  })
+
+  test("getClaimedAmounts", async (): Promise<void> => {
+    const actualClaimedAmounts: Buffer[] = claimTx.getClaimedAmounts()
+    expect(actualClaimedAmounts).toStrictEqual([
+      bintools.fromBNToBuffer(claimedAmount, 8)
+    ])
+  })
+
+  test("getClaimTo", async (): Promise<void> => {
+    const actualClaimTo: ParseableOutput = claimTx.getClaimTo()
+    const expectedClaimTo = new ParseableOutput(rewardOutputOwners)
+    expect(actualClaimTo.serialize()).toMatchObject(expectedClaimTo.serialize())
+  })
+
+  test("getClaimType", async (): Promise<void> => {
+    expect(
+      bintools
+        .fromBufferToBN(claimTx.getClaimType())
+        .cmp(ClaimType.EXPIRED_DEPOSIT_REWARD)
+    ).toBe(0)
+  })
+
+  test("getDepositTxs", async (): Promise<void> => {
+    const actualDepositTxs: Buffer[] = claimTx.getDepositTxs()
+    expect(actualDepositTxs).toStrictEqual([depositTxID])
+  })
+
+  test("addSignatureIdx", async (): Promise<void> => {
+    claimTx.addSignatureIdx(0, keychain.getAddresses()[0])
+    const actualSigIdxs: SigIdx[] = claimTx.getSigIdxs()
+    expect(actualSigIdxs.length).toBe(1)
+    expect(actualSigIdxs[0].getSource()).toStrictEqual(
+      keychain.getAddresses()[0]
+    )
+  })
+})

--- a/tests/apis/platformvm/deposittx.test.ts
+++ b/tests/apis/platformvm/deposittx.test.ts
@@ -1,0 +1,170 @@
+import BN from "bn.js"
+import { Buffer } from "buffer/"
+import {
+  KeyChain,
+  ParseableOutput,
+  PlatformVMAPI,
+  PlatformVMConstants,
+  SECPOwnerOutput,
+  SECPTransferInput,
+  SECPTransferOutput,
+  TransferableInput,
+  TransferableOutput
+} from "src/apis/platformvm"
+import { DepositTx } from "src/apis/platformvm/depositTx"
+import BinTools from "src/utils/bintools"
+import {
+  DefaultLocalGenesisPrivateKey,
+  DefaultNetworkID,
+  PrivateKeyPrefix,
+  Serialization
+} from "src/utils"
+import createHash from "create-hash"
+import { SigIdx, ZeroBN } from "src/common"
+import Avalanche from "src/index"
+
+const avalanche: Avalanche = new Avalanche(
+  "127.0.0.1",
+  9650,
+  "https",
+  12345,
+  undefined,
+  undefined
+)
+
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+const serialization: Serialization = Serialization.getInstance()
+const bintools: BinTools = BinTools.getInstance()
+let rewardOutputOwners: SECPOwnerOutput
+let platformVM: PlatformVMAPI
+let keychain: KeyChain
+let avaxAssetID: Buffer
+let secpTransferOutput: SECPTransferOutput
+let secpTransferInput: SECPTransferInput
+const depositTxID: Buffer = Buffer.from(
+  createHash("sha256")
+    .update(bintools.fromBNToBuffer(new BN(1), 32))
+    .digest()
+)
+const depositOfferID = "wVVZinZkN9x6e9dh3DNNfrmdXaHPPwKWt3Zerx2vD8Ccuo6E7"
+const depositDuration = 110376000
+
+const removeJsonProperty = (obj, property) => {
+  let json = JSON.stringify(obj)
+  const regex = new RegExp(`,?"${property}":".*?",?`, "gi")
+  json = json.replace(regex, "")
+  json = json.replace(/""/, '","')
+  return JSON.parse(json)
+}
+
+beforeAll(async () => {
+  platformVM = new PlatformVMAPI(avalanche, "/ext/bc/P")
+  keychain = platformVM.keyChain()
+  keychain.importKey(privKey)
+
+  rewardOutputOwners = new SECPOwnerOutput(
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+  avaxAssetID = await platformVM.getAVAXAssetID()
+  secpTransferInput = new SECPTransferInput(new BN(1))
+  secpTransferInput.addSignatureIdx(0, keychain.getAddresses()[0])
+
+  secpTransferOutput = new SECPTransferOutput(
+    new BN(1),
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+
+  secpTransferOutput = new SECPTransferOutput(
+    new BN(1),
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+})
+describe("DepositTx", (): void => {
+  const depositTxHex: string =
+    "00000001101010101010101010101010101010101010101010101010101010101010101000000001dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db000000070000000000000001000000000000000000000001000000013cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000001ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc500000000dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db0000000500000000000000010000000100000000000000046d656d6f7bbaa2ee5087471ec98bc49fd0d7940568a060ea0c51f1a3183b4f88a0628dd1069434400000000b000000000000000000000001000000013cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c"
+  const depositTxBuf: Buffer = Buffer.from(depositTxHex, "hex")
+  const depositTx: DepositTx = new DepositTx()
+  depositTx.fromBuffer(depositTxBuf)
+
+  test("getTypeName", async (): Promise<void> => {
+    const depositTxTypeName: string = depositTx.getTypeName()
+    expect(depositTxTypeName).toBe("DepositTx")
+  })
+
+  test("getTypeID", async (): Promise<void> => {
+    const depositTxTypeID: number = depositTx.getTypeID()
+    expect(depositTxTypeID).toBe(PlatformVMConstants.DEPOSITTX)
+  })
+
+  test("toBuffer and fromBuffer", async (): Promise<void> => {
+    const buf: Buffer = depositTx.toBuffer()
+    const asvTx: DepositTx = new DepositTx()
+    asvTx.fromBuffer(buf)
+    const buf2: Buffer = asvTx.toBuffer()
+    expect(buf.toString("hex")).toBe(buf2.toString("hex"))
+  })
+
+  test("serialize", async (): Promise<void> => {
+    const serializedDepositTx: object = depositTx.serialize()
+    const depositDurationBuf = Buffer.alloc(4)
+    depositDurationBuf.writeUInt32BE(depositDuration, 0)
+    const expectedJSON = {
+      _codecID: null,
+      _typeID: PlatformVMConstants.DEPOSITTX,
+      _typeName: "DepositTx",
+      blockchainID: serialization.encoder(
+        Buffer.alloc(32, 16),
+        "hex",
+        "Buffer",
+        "cb58"
+      ),
+      outs: [
+        new TransferableOutput(avaxAssetID, secpTransferOutput).serialize()
+      ],
+      ins: [
+        new TransferableInput(
+          depositTxID,
+          Buffer.from(bintools.fromBNToBuffer(new BN(0), 4)),
+          avaxAssetID,
+          secpTransferInput
+        ).serialize()
+      ],
+      memo: serialization
+        .typeToBuffer(bintools.cb58Encode(Buffer.from("memo")), "cb58")
+        .toString("hex"),
+      networkID: String(DefaultNetworkID).padStart(8, "0"),
+      depositOfferID: bintools.cb58Decode(depositOfferID).toString("hex"),
+      depositDuration: depositDurationBuf.toString("hex"),
+      rewardsOwner: new ParseableOutput(rewardOutputOwners).serialize()
+    }
+
+    expect(removeJsonProperty(serializedDepositTx, "source")).toStrictEqual(
+      removeJsonProperty(expectedJSON, "source")
+    )
+  })
+
+  test("getDepositOfferID", async (): Promise<void> => {
+    const actualDepositOfferID: Buffer = depositTx.getDepositOfferID()
+    expect(actualDepositOfferID).toStrictEqual(
+      bintools.cb58Decode(depositOfferID)
+    )
+  })
+
+  test("getDepositDuration", async (): Promise<void> => {
+    const actualDepositDuration: Buffer = depositTx.getDepositDuration()
+    expect(actualDepositDuration.readUInt32BE(0)).toStrictEqual(depositDuration)
+  })
+
+  test("getRewardsOwner", async (): Promise<void> => {
+    const actualRewardsOwner: ParseableOutput = depositTx.getRewardsOwner()
+    expect(actualRewardsOwner.serialize()).toMatchObject(
+      new ParseableOutput(rewardOutputOwners).serialize()
+    )
+  })
+})

--- a/tests/apis/platformvm/registernodetx.test.ts
+++ b/tests/apis/platformvm/registernodetx.test.ts
@@ -1,0 +1,179 @@
+import BN from "bn.js"
+import { Buffer } from "buffer/"
+import {
+  KeyChain,
+  PlatformVMAPI,
+  PlatformVMConstants,
+  SECPOwnerOutput,
+  SECPTransferInput,
+  SECPTransferOutput,
+  SubnetAuth,
+  TransferableInput,
+  TransferableOutput
+} from "src/apis/platformvm"
+import { RegisterNodeTx } from "src/apis/platformvm/registernodetx"
+import BinTools from "src/utils/bintools"
+import {
+  DefaultLocalGenesisPrivateKey,
+  DefaultNetworkID,
+  NodeIDStringToBuffer,
+  PrivateKeyPrefix,
+  Serialization
+} from "src/utils"
+import createHash from "create-hash"
+import { SigIdx, ZeroBN } from "src/common"
+import Avalanche from "src/index"
+import { DepositTx } from "caminojs/apis/platformvm/depositTx"
+
+const avalanche: Avalanche = new Avalanche(
+  "127.0.0.1",
+  9650,
+  "https",
+  12345,
+  undefined,
+  undefined
+)
+
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+const serialization: Serialization = Serialization.getInstance()
+const bintools: BinTools = BinTools.getInstance()
+const oldNodeID: string = "NodeID-DueWyGi3B9jtKfa9mPoecd4YSDJ1ftF69"
+const newNodeID: string = "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL"
+let rewardOutputOwners: SECPOwnerOutput
+let platformVM: PlatformVMAPI
+let keychain: KeyChain
+let avaxAssetID: Buffer
+let secpTransferOutput: SECPTransferOutput
+let secpTransferInput: SECPTransferInput
+const registerNodeTxID: Buffer = Buffer.from(
+  createHash("sha256")
+    .update(bintools.fromBNToBuffer(new BN(1), 32))
+    .digest()
+)
+const consortiumMemberAuth = new SubnetAuth()
+const depositDuration = 110376000
+
+const removeJsonProperty = (obj, property) => {
+  let json = JSON.stringify(obj)
+  const regex = new RegExp(`,?"${property}":".*?",?`, "gi")
+  json = json.replace(regex, "")
+  json = json.replace(/""/, '","')
+  return JSON.parse(json)
+}
+
+beforeAll(async () => {
+  platformVM = new PlatformVMAPI(avalanche, "/ext/bc/P")
+  keychain = platformVM.keyChain()
+  keychain.importKey(privKey)
+
+  rewardOutputOwners = new SECPOwnerOutput(
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+  avaxAssetID = await platformVM.getAVAXAssetID()
+  secpTransferInput = new SECPTransferInput(new BN(1))
+  secpTransferInput.addSignatureIdx(0, keychain.getAddresses()[0])
+  secpTransferOutput = new SECPTransferOutput(
+    new BN(1),
+    [keychain.getAddresses()[0]],
+    ZeroBN,
+    1
+  )
+  consortiumMemberAuth.addAddressIndex(Buffer.alloc(4)) // number conversion of 0 to empty Buffer
+})
+describe("RegisterNodeTx", (): void => {
+  const registerNodeTxHex: string =
+    "00000001101010101010101010101010101010101010101010101010101010101010101000000001dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db000000070000000000000001000000000000000000000001000000013cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000001ec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc500000000dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db0000000500000000000000010000000100000000000000046d656d6f8d9674f1301e38340110f9aa18fce80734628e3466265a60bcdae8e8c05901495551adccb27ea6990000000a00000001000000003cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c"
+  const registerNodeTxBuf: Buffer = Buffer.from(registerNodeTxHex, "hex")
+  const registerNodeTx: RegisterNodeTx = new RegisterNodeTx()
+  registerNodeTx.fromBuffer(registerNodeTxBuf)
+
+  test("getTypeName", async (): Promise<void> => {
+    const registerNodeTxTypeName: string = registerNodeTx.getTypeName()
+    expect(registerNodeTxTypeName).toBe("RegisterNodeTx")
+  })
+
+  test("getTypeID", async (): Promise<void> => {
+    const registerNodeTxTypeID: number = registerNodeTx.getTypeID()
+    expect(registerNodeTxTypeID).toBe(PlatformVMConstants.REGISTERNODETX)
+  })
+
+  test("toBuffer and fromBuffer", async (): Promise<void> => {
+    const buf: Buffer = registerNodeTx.toBuffer()
+    const asvTx: RegisterNodeTx = new RegisterNodeTx()
+    asvTx.fromBuffer(buf)
+    const buf2: Buffer = asvTx.toBuffer()
+    expect(buf.toString("hex")).toBe(buf2.toString("hex"))
+  })
+
+  test("serialize", async (): Promise<void> => {
+    const serializedRegisterNodeTx: object = registerNodeTx.serialize()
+    const depositDurationBuf = Buffer.alloc(4)
+    depositDurationBuf.writeUInt32BE(depositDuration, 0)
+    const expectedJSON = {
+      _codecID: null,
+      _typeID: PlatformVMConstants.REGISTERNODETX,
+      _typeName: "RegisterNodeTx",
+      blockchainID: serialization.encoder(
+        Buffer.alloc(32, 16),
+        "hex",
+        "Buffer",
+        "cb58"
+      ),
+      outs: [
+        new TransferableOutput(avaxAssetID, secpTransferOutput).serialize()
+      ],
+      ins: [
+        new TransferableInput(
+          registerNodeTxID,
+          Buffer.from(bintools.fromBNToBuffer(new BN(0), 4)),
+          avaxAssetID,
+          secpTransferInput
+        ).serialize()
+      ],
+      memo: serialization
+        .typeToBuffer(bintools.cb58Encode(Buffer.from("memo")), "cb58")
+        .toString("hex"),
+      networkID: String(DefaultNetworkID).padStart(8, "0"),
+      oldNodeID: oldNodeID,
+      newNodeID: newNodeID,
+      address: keychain.getAddresses()[0].toString("hex")
+    }
+
+    expect(
+      removeJsonProperty(serializedRegisterNodeTx, "source")
+    ).toStrictEqual(removeJsonProperty(expectedJSON, "source"))
+  })
+
+  test("addSignatureIdx", async (): Promise<void> => {
+    const registerNodeTx = new RegisterNodeTx()
+    registerNodeTx.addSignatureIdx(0, keychain.getAddresses()[0])
+    const lastSigIdx =
+      registerNodeTx.getSigIdxs()[registerNodeTx.getSigIdxs().length - 1]
+    expect(lastSigIdx["source"]).toStrictEqual(keychain.getAddresses()[0])
+  })
+
+  test("getConsortiumMemberAddress", async (): Promise<void> => {
+    const actualConsortiumMemberAddress: Buffer =
+      registerNodeTx.getConsortiumMemberAddress()
+    expect(actualConsortiumMemberAddress).toStrictEqual(
+      keychain.getAddresses()[0]
+    )
+  })
+  test("getConsortiumMemberAuth", async (): Promise<void> => {
+    const actualConsortiumMemberAuth: SubnetAuth =
+      registerNodeTx.getConsortiumMemberAuth()
+    expect(actualConsortiumMemberAuth).toStrictEqual(consortiumMemberAuth)
+  })
+
+  test("getOldNodeID", async (): Promise<void> => {
+    const actualOldNodeID: Buffer = registerNodeTx.getOldNodeID()
+    expect(actualOldNodeID).toStrictEqual(NodeIDStringToBuffer(oldNodeID))
+  })
+
+  test("getNewNodeID", async (): Promise<void> => {
+    const actualgetNewNodeID: Buffer = registerNodeTx.getNewNodeID()
+    expect(actualgetNewNodeID).toStrictEqual(NodeIDStringToBuffer(newNodeID))
+  })
+})


### PR DESCRIPTION
## Why this should be merged
New camino logic has been added without adequate test coverage. To improve/ensure quality, further testing is essential.
**Important:** The PR also contains some fixes to discrepancies found in the `fromBuffer/toBuffer` logic in the following files:

- src/apis/platformvm/claimtx.ts
- src/apis/platformvm/depositTx.ts

## How this works
It introduces new unit tests for camino logic with little to no test coverage.
Note: The field `source` is excluded from comparison in 'serialize' test cases, as it's not included in `fromBuffer/toBuffer` logic.

## How this was tested
See newly introduced unit tests.