### PR TITLE
[PVM] Custom codec typeID for baseTX

### DIFF
--- a/src/apis/platformvm/constants.ts
+++ b/src/apis/platformvm/constants.ts
@@ -20,8 +20,6 @@ export class PlatformVMConstants {
 
   static STAKEABLELOCKINID: number = 21
 
-  static BASETX: number = 0
-
   static SUBNETAUTH: number = 10
 
   static ADDVALIDATORTX: number = 12
@@ -55,7 +53,7 @@ export class PlatformVMConstants {
   static DEPOSITTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 5
   static UNLOCKDEPOSITTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 6
   static REGISTERNODETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 7
-  // static BASETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 8
+  static BASETX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 8
   static MULTISIGALIASTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 9
   static CLAIMTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 10
   static REWARDSIMPORTTX: number = PlatformVMConstants.CUSTOM_TYPE_ID + 11

--- a/tests/apis/platformvm/tx.test.ts
+++ b/tests/apis/platformvm/tx.test.ts
@@ -369,7 +369,7 @@ describe("Transactions", (): void => {
     expect(txins.length).toBe(inputs.length)
     expect(txouts.length).toBe(outputs.length)
 
-    expect(txu.getTransaction().getTxType()).toBe(0)
+    expect(txu.getTransaction().getTxType()).toBe(PlatformVMConstants.BASETX)
     expect(txu.getTransaction().getNetworkID()).toBe(12345)
     expect(txu.getTransaction().getBlockchainID().toString("hex")).toBe(
       blockchainID.toString("hex")


### PR DESCRIPTION
## Descritpion ##

This PR adds a custom typeID (`PlatformVMConstants.CUSTOM_TYPE_ID + 8`) to baseTx instead of the predefined typeID 0, so it can be handled from caminojs successfully.   