### PR TITLE
[PVM] Introduced e2e test for claiming validator rewards

### DIFF
--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -36,9 +36,7 @@ export const createTests = (tests_spec: any[]): void => {
   ] of tests_spec) {
     test(testName, async (): Promise<void> => {
       if (timeout > 0) {
-        jest.setTimeout(timeout * 2)
         await new Promise((res) => setTimeout(res, timeout))
-        jest.setTimeout(5000) // default jest timeout
       }
       if (matcher == Matcher.toBe) {
         expect(preprocess(await promise())).toBe(expected())

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,18 +15,7 @@ module.exports = {
   transformIgnorePatterns: [
     "<rootDir>/node_modules/(?!ethereum-cryptography|keccak)"
   ],
-  moduleFileExtensions: [
-    "js",
-    "ts",
-    "json",
-    "jsx",
-    "tsx",
-    "node"
-  ],
-  transform: {
-    "^.+\\.tsx?$": "ts-jest"
-  },
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  moduleFileExtensions: ["js", "ts", "json", "jsx", "tsx", "node"],
   moduleDirectories: ["node_modules", "<rootDir>/src"],
   collectCoverage: true,
   coverageReporters: ["html"],
@@ -39,5 +28,6 @@ module.exports = {
   moduleNameMapper: {
     "^src(.*)$": "<rootDir>/src$1"
   },
-  testSequencer: "<rootDir>/e2eSequencer.js"
+  testSequencer: "<rootDir>/e2eSequencer.js",
+  testTimeout: 300000 // 5 minutes
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier-mocks": "prettier --write ./__mocks__",
     "prettier-workflows": "prettier --write .github/**/*.yml",
     "prettier": "yarn prettier-src && yarn prettier-examples && yarn prettier-tests && yarn prettier-mocks && yarn prettier-workflows",
-    "prettier-check": "prettier --check ./src ./examples ./tests ./__mocks__ .github/**/*.yml",
+    "prettier-check": "prettier --check ./src ./e2e_tests ./examples ./tests ./__mocks__ .github/**/*.yml",
     "release:prepare": "rm -rf ./dist ./node_modules && yarn install && yarn build && yarn bundle && yarn test && git status",
     "test": "jest",
     "test-watch": "jest --watch",


### PR DESCRIPTION
## Why this should be merged
To add test coverage to the scenario of a validator claiming rewards. These rewards get exported to from C->P after an adequate number of txs on cchain have accumulated enough gas fees.

The PR addresses the following 2 issues:

- jest timeout has been moved from e2etestlib to jest central configuration, since setting the timeout individually for each test did not make any sense as test could affect the other.
- duplicate configs in jest.config.js have been removed (see 'transform' and 'moduleFileExtensions')

## How this works
A dummy SC is deployed repeatedly on C Chain to accumulate gas fees. Then enough time (>feeRewardExportMinTimeInterval) is waited and a claim tx for a minimum amount is triggered for one of the validators. Finally, it's verified the claim tx gets committed and that the unlocked amounts of the validator are increased accordingly

## How this was tested
Via newly introduced e2e test.
