### PR TITLE
[PVM] Added missing condition for claimtx in SelectTxClass

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -2508,7 +2508,7 @@ export class PlatformVMAPI extends JRPCAPI {
    */
   buildClaimTx = async (
     utxoset: UTXOSet,
-    fromAddresses: string[],
+    fromAddresses: FromType,
     changeAddresses: string[] = undefined,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1438,8 +1438,9 @@ export class Builder {
    * @param depositTxIDs The deposit transactions ids with which the claiblable rewards are associated
    * @param claimableOwnerIDs The ownerIDs of the rewards to claim
    * @param claimedAmounts The amounts of the rewards to claim
-   * @param claimType The type of claim tx
    * @param claimTo The address to claimed rewards will be directed to
+   * @param claimType The type of claim tx
+   * @param claimableSigners The signers of the claimable rewards
    *
    * @returns An unsigned ClaimTx created from the passed in parameters.
    */

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -29,6 +29,7 @@ import { TransactionError } from "../../utils/errors"
 import { RegisterNodeTx } from "./registernodetx"
 import { DepositTx } from "./depositTx"
 import { AddressStateTx } from "./addressstatetx"
+import { ClaimTx } from "./claimtx"
 
 /**
  * @ignore
@@ -63,6 +64,8 @@ export const SelectTxClass = (txtype: number, ...args: any[]): BaseTx => {
     return new DepositTx(...args)
   } else if (txtype === PlatformVMConstants.ADDRESSSTATETX) {
     return new AddressStateTx(...args)
+  } else if (txtype === PlatformVMConstants.CLAIMTX) {
+    return new ClaimTx(...args)
   }
   /* istanbul ignore next */
   throw new TransactionError("Error - SelectTxClass: unknown txtype")


### PR DESCRIPTION
## Why this should be merged
While introducing the new claimtx logic, no consideration was made for the deserialization of unsignedtx of type ClaimTx.

## How this works
Adds an if condition for the claimtx in SelectTxClass logic 

## How this was tested
Manually

Note: Also changed fromAddresses type from string[] to FromType in buildClaimTx.