### PR TITLE
[PVM] Fixed deserialization logic for claimtx field 'claimTo'

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -627,7 +627,6 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
       "Issue a claimTx",
       () =>
         (async function () {
-          const claimableSigners: [number, Buffer][] = [[0, pAddresses[1]]]
           const unsignedTx: UnsignedTx = await pChain.buildClaimTx(
             undefined,
             [P(addrB)],
@@ -639,8 +638,8 @@ describe("Camino-PChain-Auto-Unlock-Deposit-Full-Amount", (): void => {
             [rewardsOwner],
             [oneMinRewardsAmount],
             rewardsOwner,
-            ClaimType.EXPIRED_DEPOSIT_REWARD,
-            claimableSigners
+            [pAddresses[1]],
+            ClaimType.EXPIRED_DEPOSIT_REWARD
           )
           const claimTx: Tx = unsignedTx.sign(pKeychain)
           return pChain.issueTx(claimTx)

--- a/src/apis/platformvm/claimtx.ts
+++ b/src/apis/platformvm/claimtx.ts
@@ -55,6 +55,8 @@ export class ClaimTx extends BaseTx {
       "Buffer",
       8
     )
+
+    this.claimTo = new ParseableOutput()
     this.claimTo.deserialize(fields["claimTo"], encoding)
 
     // initialize other num fields

--- a/src/apis/platformvm/index.ts
+++ b/src/apis/platformvm/index.ts
@@ -1,6 +1,7 @@
 export * from "./api"
 export * from "./addsubnetvalidatortx"
 export * from "./basetx"
+export * from "./claimtx"
 export * from "./constants"
 export * from "./createchaintx"
 export * from "./createsubnettx"


### PR DESCRIPTION
## Why this should be merged
Calling the deserialize method on a claimtx serialized object causes an error since the field claimTo is referenced before it's initialized.

## How this works
Initializes the field `claimTo` before calling the `deserialize` method upon it.

## How this was tested
Manually

Note: also contains a fix in an e2e test related to the changed signature `buildClaimTx`.