### PR TITLE
[WORKFLOW] Made last 2 actions conditional on the existence of a PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,11 +110,12 @@ jobs:
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: find_comment
+        if: ${{ github.event.pull_request.number }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "Found errors/fatal log records."
       - name: Create PR comment if errors/fatal logs produced
-        if: ${{ steps.check-logs.outputs.errors > 0 || steps.check-logs.outputs.fatal > 0 }}
+        if: $${{ github.event.pull_request.number }} && ({{ steps.check-logs.outputs.errors > 0 || steps.check-logs.outputs.fatal > 0 }})
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "Found errors/fatal log records."
       - name: Create PR comment if errors/fatal logs produced
-        if: $${{ github.event.pull_request.number }} && ({{ steps.check-logs.outputs.errors > 0 || steps.check-logs.outputs.fatal > 0 }})
+        if: ${{ github.event.pull_request.number }} && (${{ steps.check-logs.outputs.errors > 0 || steps.check-logs.outputs.fatal > 0 }})
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why this should be merged
The last 2 actions in the e2e workflow depend on the existence of a PR as they create a comment on the said PR to notify the author/reviewers of possible errors in the node logs.
Since the workflow can be also triggered directly, the existence of a PR is not always given. Therefore, these actions have been turned into conditional and run only on workflows triggered by PRs. 

## How this works
Uses the `if` condition in github yml syntax to make the respective action steps conditional.

## How this was tested
Can be tested after merged. 
