### PR TITLE
[CaminoAddVal] Add nodeOwnerAuth

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -61,7 +61,7 @@ const delegationFee: number = 10
 const threshold: number = 1
 const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from(
-  "PlatformVM utility method buildAddValidatorTx to add a validator to the primary subnet"
+  "PlatformVM utility method buildCaminoAddValidatorTx to add a validator to the primary subnet"
 )
 const interestRateDenominator = new BN(1_000_000 * (365 * 24 * 60 * 60))
 const P = function (s: string): string {
@@ -133,17 +133,20 @@ describe("Camino-PChain-Add-Validator", (): void => {
       () =>
         (async function () {
           const stakeAmount: any = await pChain.getMinStake()
-          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+          const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             undefined,
             [P(adminAddress)],
             [P(adminAddress)],
             [P(adminAddress)],
             adminNodeId,
+            {
+              address: P(adminAddress),
+              auth: [[0, P(adminAddress)]]
+            },
             startTime,
             endTime,
             stakeAmount.minValidatorStake,
             [P(adminAddress)],
-            delegationFee,
             locktime,
             threshold,
             memo
@@ -161,17 +164,20 @@ describe("Camino-PChain-Add-Validator", (): void => {
       () =>
         (async function () {
           const stakeAmount: any = await pChain.getMinStake()
-          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+          const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             undefined,
             [P(adminAddress)],
             [P(adminAddress)],
             [P(adminAddress)],
             node6Id,
+            {
+              address: P(adminAddress),
+              auth: [[0, P(adminAddress)]]
+            },
             startTime,
             endTime,
             stakeAmount.minValidatorStake,
             [P(adminAddress)],
-            delegationFee,
             locktime,
             threshold,
             memo
@@ -235,17 +241,20 @@ describe("Camino-PChain-Add-Validator", (): void => {
       () =>
         (async function () {
           const stakeAmount: any = await pChain.getMinStake()
-          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+          const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             undefined,
             [P(addrB)], // "X-kopernikus1s93gzmzuvv7gz8q4l83xccrdchh8mtm3xm5s2g"
             [P(addrB)],
             [P(addrB)],
             node6Id,
+            {
+              address: P(addrB),
+              auth: [[0, P(addrB)]]
+            },
             startTime,
             endTime,
             stakeAmount.minValidatorStake,
             [P(addrB)],
-            delegationFee,
             locktime,
             threshold,
             memo
@@ -903,17 +912,20 @@ describe("Camino-PChain-Multisig", (): void => {
           ])
           const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
 
-          const unsignedTx: UnsignedTx = await pChain.buildAddValidatorTx(
+          const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             utxoSet,
             [P(multiSigAliasAddr)],
             [[P(multiSigAliasAddr)], [pAddressStrings[5]]],
             [P(multiSigAliasAddr)],
             node7Id, // the node where the alias is registered
+            {
+              address: P(multiSigAliasAddr),
+              auth: [[0, pAddressStrings[5]]]
+            },
             startTime,
             endTime,
             new BN(2000000000000),
             [P(multiSigAliasAddr)],
-            0,
             undefined,
             threshold,
             undefined,

--- a/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig-from-separate-signatures.ts
+++ b/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig-from-separate-signatures.ts
@@ -196,17 +196,20 @@ const sendAddValidatorTx = async (): Promise<any> => {
     let startDate = new Date(Date.now() + 0.5 * 60 * 1000).getTime() / 1000
     let endDate = startDate + 60 * 60 * 24 * 10
 
-    const unsignedTx: UnsignedTx = await pchain.buildAddValidatorTx(
+    const unsignedTx: UnsignedTx = await pchain.buildCaminoAddValidatorTx(
       utxoSet,
       [msigAlias],
       [[msigAlias], pAddressStrings],
       [msigAlias],
       nodeID,
+      {
+        address: msigAlias,
+        auth: [[0, msigAliasArray[0]]]
+      },
       new BN(startDate),
       new BN(endDate),
       new BN(2000000000000),
       [msigAlias],
-      0, // delegation fee
       undefined,
       threshold,
       undefined,

--- a/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig.ts
+++ b/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig.ts
@@ -135,17 +135,20 @@ const sendAddValidatorTx = async (): Promise<any> => {
   let startDate = new Date(Date.now() + 0.5 * 60 * 1000).getTime() / 1000
   let endDate = startDate + 60 * 60 * 24 * 10
 
-  const unsignedTx: UnsignedTx = await pchain.buildAddValidatorTx(
+  const unsignedTx: UnsignedTx = await pchain.buildCaminoAddValidatorTx(
     utxoSet,
     [msigAlias],
     [[msigAlias], pAddressStrings],
     [msigAlias],
     nodeID,
+    {
+      address: msigAlias,
+      auth: [[0, msigAliasArray[0]]]
+    },
     new BN(startDate),
     new BN(endDate),
     new BN(2000000000000),
     [msigAlias],
-    0, // delegation fee
     undefined,
     threshold,
     undefined,

--- a/src/apis/platformvm/validationtx.ts
+++ b/src/apis/platformvm/validationtx.ts
@@ -6,8 +6,8 @@
 import BN from "bn.js"
 import BinTools from "../../utils/bintools"
 import { BaseTx } from "./basetx"
-import { TransferableOutput } from "../platformvm/outputs"
-import { TransferableInput } from "../platformvm/inputs"
+import { TransferableOutput } from "./outputs"
+import { TransferableInput } from "./inputs"
 import { Buffer } from "buffer/"
 import { PlatformVMConstants } from "./constants"
 import { DefaultNetworkID } from "../../utils/constants"
@@ -15,6 +15,10 @@ import { bufferToNodeIDString } from "../../utils/helperfunctions"
 import { AmountOutput, ParseableOutput } from "./outputs"
 import { Serialization, SerializedEncoding } from "../../utils/serialization"
 import { DelegationFeeError } from "../../utils/errors"
+import { Credential, SigIdx, Signature } from "../../common"
+import { SubnetAuth } from "./subnetauth"
+import { KeyChain, KeyPair } from "./keychain"
+import { SelectCredentialClass } from "./credentials"
 
 /**
  * @ignore
@@ -547,6 +551,55 @@ export class AddValidatorTx extends AddDelegatorTx {
 export class CaminoAddValidatorTx extends AddValidatorTx {
   protected _typeName = "CaminoAddValidatorTx"
   protected _typeID = PlatformVMConstants.CAMINOADDVALIDATORTX
+
+  // signatures
+  protected nodeOwnerAuth: SubnetAuth = new SubnetAuth()
+  protected sigIdxs: SigIdx[] = [] // idxs of registered nodeID owner
+
+  addSignatureIdx(addressIdx: number, address: Buffer): void {
+    const sigIdx = new SigIdx(addressIdx, address)
+    this.sigIdxs.push(sigIdx)
+    this.nodeOwnerAuth.addAddressIndex(sigIdx.getBytes())
+  }
+
+  getCredentialID(): number {
+    return PlatformVMConstants.SECPCREDENTIAL
+  }
+
+  fromBuffer(bytes: Buffer, offset: number = 0): number {
+    offset = super.fromBuffer(bytes, offset)
+
+    this.nodeOwnerAuth = new SubnetAuth()
+    offset += this.nodeOwnerAuth.fromBuffer(bytes, offset)
+
+    return offset
+  }
+
+  toBuffer(): Buffer {
+    let superBuff = super.toBuffer()
+    let bsize = superBuff.length
+
+    const authBuf = this.nodeOwnerAuth.toBuffer()
+    bsize += authBuf.length
+
+    return Buffer.concat([superBuff, authBuf], bsize)
+  }
+
+  sign(msg: Buffer, kc: KeyChain): Credential[] {
+    const creds = super.sign(msg, kc)
+
+    const cred = SelectCredentialClass(this.getCredentialID())
+    for (const sigIdx of this.sigIdxs) {
+      const keypair: KeyPair = kc.getKey(sigIdx.getSource())
+      const signval: Buffer = keypair.sign(msg)
+      const sig: Signature = new Signature()
+      sig.fromBuffer(signval)
+      cred.addSignature(sig)
+    }
+    creds.push(cred)
+
+    return creds
+  }
 
   /**
    * Class representing an unsigned CaminoAddValidatorTx transaction.


### PR DESCRIPTION
## CaminoAddValidator Change
CaminoAddValidator verifies the registered nodeowner currently using Credentials from inputs.
This assumption was agreed because we expected that at least 1 input to bond is owned by the person who registered the node.

For Mnemonic walleds this assumtion fails, because after first TX (e.g.RegisterNode) the chnage can be completely owned by a HD derived address.

Camino-Node introduces a SubnetAuth for this -> This PR adapts these changes.