### PR TITLE
[PVM] Added getters in claimtx

### DIFF
--- a/src/apis/platformvm/claimtx.ts
+++ b/src/apis/platformvm/claimtx.ts
@@ -114,6 +114,16 @@ export class ClaimAmount {
       this.amount = bintools.fromBNToBuffer(amount, 8)
     if (typeof auth != "undefined") this.auth.setAddressIndices(auth)
   }
+
+  getID(): Buffer {
+    return this.id
+  }
+  getType(): Buffer {
+    return this.type
+  }
+  getAmount(): Buffer {
+    return this.amount
+  }
 }
 
 /**
@@ -151,6 +161,9 @@ export class ClaimTx extends BaseTx {
     return this._typeID
   }
 
+  getClaimAmounts(): ClaimAmount[] {
+    return this.claimAmounts
+  }
   /**
    * Takes a {@link https://github.com/feross/buffer|Buffer} containing a [[ClaimTx]], parses it, populates the class, and returns the length of the [[ClaimTx]] in bytes.
    *

--- a/tests/apis/platformvm/claimtx.test.ts
+++ b/tests/apis/platformvm/claimtx.test.ts
@@ -105,6 +105,13 @@ describe("ClaimTx", (): void => {
     expect(claimTxTypeID).toBe(PlatformVMConstants.CLAIMTX)
   })
 
+  test("getClaimAmounts", async (): Promise<void> => {
+    const claimAmounts: ClaimAmount[] = claimTx.getClaimAmounts()
+    expect(claimAmounts).toStrictEqual([
+      new ClaimAmount(ownerID, ClaimType.EXPIRED_DEPOSIT_REWARD, new BN(1))
+    ])
+  })
+
   test("toBuffer and fromBuffer", async (): Promise<void> => {
     const buf: Buffer = claimTx.toBuffer()
     const asvTx: ClaimTx = new ClaimTx()


### PR DESCRIPTION
## Why this should be merged
Protected fields of claimtx such as claimAmounts need to be accessible by the apps using caminojs such as camino-wallet.

## How this works
Adds getters for the `claimAmounts` field as well as for certain `ClaimAmount`  fields.

## How this was tested
Unit tests