### PR TITLE
[GITHUB] New CD job for publishing npm package to registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:
@@ -19,6 +19,10 @@ on:
         description: "caminojs branch"
         required: true
         default: "chain4travel"
+      release:
+        description: "Publish to npm"
+        required: false
+        default: "false"
 
 env:
   CI: true
@@ -47,3 +51,14 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn prettier-check
       - run: yarn test
+  Release:
+    if: ${{ github.event.inputs.release == 'true'}}
+    needs: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=\${{ secrets.NPM_TOKEN }}" > .npmrc
+          yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Why this should be merged
It should be able for this js library to be imported to other projects when needed as an npm package to facilitate further development.

## How this works
Introduces new job in the github yml for releasing a new npm package on the npm registry. The new job depends on the existing 'Test' job and is by default deactivated. To be able to release the npm package you need to pass the value `true` to the input field  `release`.

## How this was tested
