### PR TITLE
[TX] Add getter for multisigalias owners

### DIFF
--- a/src/apis/platformvm/multisigaliastx.ts
+++ b/src/apis/platformvm/multisigaliastx.ts
@@ -44,6 +44,10 @@ export class MultisigAlias {
     return this.memo
   }
 
+  getOwners(): ParseableOutput {
+    return this.owners
+  }
+
   deserialize(fields: object, encoding: SerializedEncoding = "hex"): this {
     this.id = serialization.decoder(fields["id"], encoding, "cb58", "Buffer")
     this.memo = serialization.decoder(


### PR DESCRIPTION
## Why this should be merged
Upon deserializatoin of a `multisigaliastx`, the consumer needs to access and evaluate the property `owners` of a `MultisigAlias`.

## How this works
Adds a getter for the `owners` property of a `MultisigAlias`

## How this was tested