### PR TITLE
[API] replace obsolete creationTxFee with createAssetTxFee in network…

### DIFF
--- a/examples/avm/getCreationTxFee.ts
+++ b/examples/avm/getCreationTxFee.ts
@@ -9,10 +9,10 @@ const avalanche: Avalanche = new Avalanche(
   config.protocol,
   config.networkID
 )
-const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txFee: BN = xchain.getCreationTxFee()
+  await avalanche.fetchNetworkSettings()
+  const txFee: BN = avalanche.XChain().getCreationTxFee()
   console.log(txFee)
 }
 

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -202,7 +202,7 @@ export class AVMAPI extends JRPCAPI {
    * @returns The default creation fee as a {@link https://github.com/indutny/bn.js/|BN}
    */
   getDefaultCreationTxFee = (): BN => {
-    return new BN(this.core.getNetwork().X.creationTxFee)
+    return new BN(this.core.getNetwork().X.createAssetTxFee)
   }
 
   /**

--- a/src/apis/info/api.ts
+++ b/src/apis/info/api.ts
@@ -111,7 +111,6 @@ export class InfoAPI extends JRPCAPI {
     const response: RequestResponseData = await this.callMethod("info.getTxFee")
     return {
       txFee: new BN(response.data.result.txFee, 10),
-      creationTxFee: new BN(response.data.result.creationTxFee, 10),
       createAssetTxFee: new BN(response.data.result.createAssetTxFee, 10),
       createSubnetTxFee: new BN(response.data.result.createSubnetTxFee, 10),
       createBlockchainTxFee: new BN(

--- a/src/apis/info/interfaces.ts
+++ b/src/apis/info/interfaces.ts
@@ -28,7 +28,6 @@ export interface PeersResponse {
 
 export interface GetTxFeeResponse {
   txFee: BN
-  creationTxFee: BN
   createAssetTxFee: BN
   createSubnetTxFee: BN
   createBlockchainTxFee: BN

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -273,7 +273,7 @@ export class PlatformVMAPI extends JRPCAPI {
    * @returns The default creation fee as a {@link https://github.com/indutny/bn.js/|BN}
    */
   getDefaultCreationTxFee = (): BN => {
-    return new BN(this.core.getNetwork().P.creationTxFee)
+    return new BN(this.core.getNetwork().P.createAssetTxFee)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,13 +175,13 @@ export default class Avalanche extends AvalancheCore {
         avaxAssetAlias: response.assetSymbol,
         blockchainID: xchain["id"],
         vm: XChainVMName,
-        creationTxFee: fees.creationTxFee,
+        createAssetTxFee: fees.createAssetTxFee,
         txFee: fees.txFee
       },
       P: {
         alias: PChainAlias,
         blockchainID: DefaultPlatformChainID,
-        creationTxFee: fees.creationTxFee,
+        createAssetTxFee: fees.createAssetTxFee,
         createSubnetTx: fees.createSubnetTxFee,
         createChainTx: fees.createBlockchainTxFee,
         maxConsumption: response.maxConsumptionRate,

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -42,7 +42,7 @@ export interface X {
   blockchainID: string
   alias: string
   vm: string
-  creationTxFee: BN | number
+  createAssetTxFee: BN | number
   avaxAssetID: string
   avaxAssetAlias: string
   txFee?: BN | number
@@ -54,7 +54,7 @@ export interface P {
   blockchainID: string
   alias: string
   vm: string
-  creationTxFee: BN | number
+  createAssetTxFee: BN | number
   createSubnetTx: BN | number
   createChainTx: BN | number
   minConsumption: number
@@ -95,7 +95,7 @@ const TestNetwork: Network = {
     avaxAssetID: TestAvaxAssetID,
     avaxAssetAlias: "AVAX",
     txFee: MILLIAVAX,
-    creationTxFee: CENTIAVAX,
+    createAssetTxFee: CENTIAVAX,
     mintTxFee: MILLIAVAX
   },
   P: {
@@ -103,7 +103,7 @@ const TestNetwork: Network = {
     alias: PChainAlias,
     vm: PChainVMName,
     txFee: MILLIAVAX,
-    creationTxFee: CENTIAVAX,
+    createAssetTxFee: CENTIAVAX,
     createSubnetTx: ONEAVAX,
     createChainTx: ONEAVAX,
     minConsumption: 0.1,
@@ -143,7 +143,7 @@ const AvaxMainNetwork: Network = {
     avaxAssetID: "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
     avaxAssetAlias: "AVAX",
     txFee: MILLIAVAX,
-    creationTxFee: CENTIAVAX,
+    createAssetTxFee: CENTIAVAX,
     mintTxFee: MILLIAVAX
   },
   P: {
@@ -151,7 +151,7 @@ const AvaxMainNetwork: Network = {
     alias: PChainAlias,
     vm: PChainVMName,
     txFee: MILLIAVAX,
-    creationTxFee: CENTIAVAX,
+    createAssetTxFee: CENTIAVAX,
     createSubnetTx: ONEAVAX,
     createChainTx: ONEAVAX,
     minConsumption: 0.1,

--- a/tests/apis/avm/api.test.ts
+++ b/tests/apis/avm/api.test.ts
@@ -1478,7 +1478,7 @@ describe("AVMAPI", (): void => {
     })
 
     test("buildCreateAssetTx - Variable Cap", async (): Promise<void> => {
-      avm.setCreationTxFee(new BN(avalanche.getNetwork().P["creationTxFee"]))
+      avm.setCreationTxFee(new BN(avalanche.getNetwork().P.createAssetTxFee))
       const mintOutputs: SECPMintOutput[] = [secpMintOut1, secpMintOut2]
       const txu1: UnsignedTx = await avm.buildCreateAssetTx(
         set,

--- a/tests/apis/info/api.test.ts
+++ b/tests/apis/info/api.test.ts
@@ -68,11 +68,11 @@ describe("Info", (): void => {
   })
 
   test("getTxFee", async (): Promise<void> => {
-    const result: Promise<{ txFee: BN; creationTxFee: BN }> = info.getTxFee()
+    const result: Promise<{ txFee: BN; createAssetTxFee: BN }> = info.getTxFee()
     const payload: object = {
       result: {
         txFee: "1000000",
-        creationTxFee: "10000000"
+        createAssetTxFee: "10000000"
       }
     }
     const responseObj: HttpResponse = {
@@ -80,11 +80,11 @@ describe("Info", (): void => {
     }
 
     mockAxios.mockResponse(responseObj)
-    const response: { txFee: BN; creationTxFee: BN } = await result
+    const response: { txFee: BN; createAssetTxFee: BN } = await result
 
     expect(mockAxios.request).toHaveBeenCalledTimes(1)
     expect(response.txFee.eq(new BN("1000000"))).toBe(true)
-    expect(response.creationTxFee.eq(new BN("10000000"))).toBe(true)
+    expect(response.createAssetTxFee.eq(new BN("10000000"))).toBe(true)
   })
 
   test("getNetworkName", async (): Promise<void> => {


### PR DESCRIPTION
## Why this should be merged
The erroneous retrieval of the fee responsible for creating an asset is currently obstructing any asset creation.
See also: https://github.com/chain4travel/caminogo/commit/1ecab0008e3dbe41684934bf7e101bacd48ba8da

## How this works
Replace obsolete property creationTxFee of info api with createAssetTxFee

## How this was tested
By comparing results of example `examples/avm/getCreationTxFee.ts` before and after the change + adjusted unit tests