### PR TITLE
[TX] Fix owner auth signatures indices for DepositTx + examples

### DIFF
--- a/examples/platformvm/buildAddressStateTx.ts
+++ b/examples/platformvm/buildAddressStateTx.ts
@@ -7,6 +7,7 @@ import {
   AddressState
 } from "caminojs/apis/platformvm"
 import { ExamplesConfig } from "../common/examplesConfig"
+import { DefaultLocalGenesisPrivateKey2 } from "caminojs/utils"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")
 const avalanche: Avalanche = new Avalanche(
@@ -19,8 +20,7 @@ const avalanche: Avalanche = new Avalanche(
 /**
  * @ignore
  */
-let privKey: string =
-  "PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE"
+let privKey: string = `PrivateKey-${DefaultLocalGenesisPrivateKey2}`
 
 let pchain: PlatformVMAPI
 let pKeychain: KeyChain
@@ -40,7 +40,7 @@ const main = async (): Promise<any> => {
   await InitAvalanche()
 
   const address = pAddressStrings[0]
-  const state = AddressState.ROLE_KYC
+  const state = AddressState.OFFERS_CREATOR
   const remove = false
   const memo: Buffer = Buffer.from(
     "Utility function to create an AddressStateTx transaction"

--- a/examples/platformvm/buildDepositTx-v1-MsigDepositor.ts
+++ b/examples/platformvm/buildDepositTx-v1-MsigDepositor.ts
@@ -1,0 +1,159 @@
+import { Avalanche, BinTools, Buffer } from "caminojs/index"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  UnsignedTx,
+  PlatformVMConstants,
+  DepositTx
+} from "caminojs/apis/platformvm"
+import { OutputOwners } from "caminojs/common/output"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey2,
+  PChainAlias
+} from "caminojs/utils"
+import { ExamplesConfig } from "../common/examplesConfig"
+import BN from "bn.js"
+import createHash from "create-hash"
+import {
+  MultisigKeyChain,
+  MultisigKeyPair,
+  SignerKeyPair
+} from "caminojs/common"
+
+const config: ExamplesConfig = require("../common/examplesConfig.json")
+const avalanche: Avalanche = new Avalanche(
+  config.host,
+  config.port,
+  config.protocol,
+  config.networkID
+)
+const ownerPrivKey: string =
+  "PrivateKey-Ge71NJhUY3TjZ9dLohijSnNq46QxobjqxHGMUDAPoVsNFA93w"
+const msigAlias = "P-kopernikus1t5qgr9hcmf2vxj7k0hz77kawf9yr389cxte5j0"
+const pkeys = [
+  "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
+  "PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE"
+]
+const owner = {
+  addresses: [
+    "P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68",
+    "P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+  ],
+  threshold: 2,
+  locktime: 0
+}
+
+const bintools: BinTools = BinTools.getInstance()
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey2}`
+let pchain: PlatformVMAPI
+let pKeychain: KeyChain
+let pAddresses: Buffer[]
+let pAddressStrings: string[]
+
+const InitAvalanche = async () => {
+  await avalanche.fetchNetworkSettings()
+  pchain = avalanche.PChain()
+  pKeychain = pchain.keyChain()
+  // pKeychain.importKey(privKey) // P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
+  pKeychain.importKey(pkeys[0]) // P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68
+  pKeychain.importKey(pkeys[1]) // P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
+  pAddresses = pchain.keyChain().getAddresses()
+  pAddressStrings = pchain.keyChain().getAddressStrings()
+}
+
+const main = async (): Promise<any> => {
+  await InitAvalanche()
+  const depositOwner = "P-kopernikus13kyf72ftu4l77kss7xm0kshm0au29s48zjaygq"
+  const msigAliasBuffer = pchain.parseAddress(msigAlias)
+  const amountToLock = new BN(1000000)
+  const depositOfferID = "2kRcnwGMJGZPQGKtq2ayBTsxjUaGdDSRphVfHV9KLHvuWhykgR"
+  const depositDuration = 110
+  const memo: Buffer = Buffer.from("DepositTx v1 with msig deposit creator")
+  const rewardsOwner = new OutputOwners([msigAliasBuffer], undefined, 1)
+
+  const depositCreator = msigAlias // Warning: this address must have the role OFFERS_CREATOR
+  const depositCreatorAuth: [number, string | Buffer][] = [[0, depositCreator]]
+
+  const depositOfferOwnerAuth: [number, string | Buffer][] = [[1, depositOwner]]
+
+  // hash concatenated bytes of offer id and deposit owner address
+  const msgHashed: Buffer = Buffer.from(
+    createHash("sha256")
+      .update(
+        Buffer.concat([bintools.cb58Decode(depositOfferID), msigAliasBuffer])
+      )
+      .digest()
+  )
+
+  const keypair: SignerKeyPair = pKeychain.importKey(ownerPrivKey)
+  // sign the hash
+  const signatureBuffer: Buffer = keypair.sign(msgHashed)
+
+  const unsignedTx: UnsignedTx = await pchain.buildDepositTx(
+    1,
+    undefined,
+    pAddressStrings,
+    pAddressStrings,
+    depositOfferID,
+    depositDuration,
+    rewardsOwner,
+    depositCreator,
+    depositCreatorAuth,
+    [signatureBuffer],
+    depositOfferOwnerAuth,
+    memo,
+    new BN(0),
+    amountToLock
+  )
+
+  // Create the hash from the tx
+  const txbuff = unsignedTx.toBuffer()
+  const msg: Buffer = Buffer.from(createHash("sha256").update(txbuff).digest())
+
+  // Create the Multisig keychain
+  const addresses = owner.addresses.map((a) => bintools.parseAddress(a, "P"))
+  const outputOwners = new OutputOwners(
+    addresses,
+    new BN(owner.locktime),
+    owner.threshold
+  )
+
+  const numAddresses =
+    depositOfferOwnerAuth.length > 0
+      ? depositOfferOwnerAuth.at(depositOfferOwnerAuth.length - 1)[0]
+      : 0
+
+  const msKeyChain = new MultisigKeyChain(
+    avalanche.getHRP(),
+    PChainAlias,
+    msg,
+    PlatformVMConstants.SECPMULTISIGCREDENTIAL,
+    unsignedTx.getTransaction().getOutputOwners(),
+    new Map([[msigAliasBuffer.toString("hex"), outputOwners]])
+  )
+
+  for (const address of pAddresses) {
+    // We need the keychain for signing
+    const keyPair = pKeychain.getKey(address)
+    // The signature
+    const signature = keyPair.sign(msg)
+    msKeyChain.addKey(new MultisigKeyPair(msKeyChain, address, signature))
+  }
+
+  // Add owner signatures to the multisig keychain
+  const sigs = (unsignedTx.getTransaction() as DepositTx).getOwnerSignatures()
+  sigs.forEach((v) => {
+    msKeyChain.addKey(new MultisigKeyPair(msKeyChain, v[0], v[1]))
+  })
+
+  // Create signature indices (throws if not able to do so)
+  msKeyChain.buildSignatureIndices()
+
+  // Sign the transaction with msig keychain and issue
+  const tx = unsignedTx.sign(msKeyChain)
+  const txid = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/buildDepositTx-v1-MsigDepositorDifferentRewardsOwner.ts
+++ b/examples/platformvm/buildDepositTx-v1-MsigDepositorDifferentRewardsOwner.ts
@@ -1,0 +1,163 @@
+import { Avalanche, BinTools, Buffer } from "caminojs/index"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  UnsignedTx,
+  PlatformVMConstants,
+  DepositTx
+} from "caminojs/apis/platformvm"
+import { OutputOwners } from "caminojs/common/output"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey2,
+  PChainAlias
+} from "caminojs/utils"
+import { ExamplesConfig } from "../common/examplesConfig"
+import BN from "bn.js"
+import createHash from "create-hash"
+import {
+  MultisigKeyChain,
+  MultisigKeyPair,
+  SignerKeyPair
+} from "caminojs/common"
+
+const config: ExamplesConfig = require("../common/examplesConfig.json")
+const avalanche: Avalanche = new Avalanche(
+  config.host,
+  config.port,
+  config.protocol,
+  1002
+)
+const ownerPrivKey: string =
+  "PrivateKey-Ge71NJhUY3TjZ9dLohijSnNq46QxobjqxHGMUDAPoVsNFA93w"
+const msigAlias = "P-kopernikus1t5qgr9hcmf2vxj7k0hz77kawf9yr389cxte5j0"
+const pkeys = [
+  "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
+  "PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE"
+]
+const owner = {
+  addresses: [
+    "P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68",
+    "P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+  ],
+  threshold: 2,
+  locktime: 0
+}
+
+const bintools: BinTools = BinTools.getInstance()
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey2}`
+let pchain: PlatformVMAPI
+let pKeychain: KeyChain
+let pAddresses: Buffer[]
+let pAddressStrings: string[]
+
+const InitAvalanche = async () => {
+  await avalanche.fetchNetworkSettings()
+  pchain = avalanche.PChain()
+  pKeychain = pchain.keyChain()
+  // pKeychain.importKey(privKey) // P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
+  pKeychain.importKey(pkeys[0]) // P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68
+  pKeychain.importKey(pkeys[1]) // P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
+  pAddresses = pchain.keyChain().getAddresses()
+  pAddressStrings = pchain.keyChain().getAddressStrings()
+}
+
+const main = async (): Promise<any> => {
+  await InitAvalanche()
+  const depositOwner = "P-kopernikus13kyf72ftu4l77kss7xm0kshm0au29s48zjaygq"
+  const msigAliasBuffer = pchain.parseAddress(msigAlias)
+  const amountToLock = new BN(1000000)
+  const depositOfferID = "25eMunyfWkeE1DFCK6J1yz2zZd8DtG37SshPiyua1BzkH9HFtj"
+  const depositDuration = 110
+  const memo: Buffer = Buffer.from("DepositTx v1 with msig deposit creator")
+  const rewardsOwnerBuffer = msigAliasBuffer
+  const rewardsOwner = new OutputOwners([rewardsOwnerBuffer], undefined, 1)
+
+  const depositCreator = msigAlias // Warning: this address must have the role OFFERS_CREATOR
+  const depositCreatorAuth: [number, string | Buffer][] = [[0, depositCreator]]
+
+  const depositOfferOwnerAuth: [number, string | Buffer][] = [[1, depositOwner]]
+
+  // hash concatenated bytes of offer id and deposit owner address
+  const msgHashed: Buffer = Buffer.from(
+    createHash("sha256")
+      .update(
+        Buffer.concat([bintools.cb58Decode(depositOfferID), msigAliasBuffer])
+      )
+      .digest()
+  )
+
+  const keypair: SignerKeyPair = pKeychain.importKey(ownerPrivKey)
+  // sign the hash
+  const signatureBuffer: Buffer = keypair.sign(msgHashed)
+
+  const unsignedTx: UnsignedTx = await pchain.buildDepositTx(
+    1,
+    undefined,
+    pAddressStrings,
+    pAddressStrings,
+    depositOfferID,
+    depositDuration,
+    rewardsOwner,
+    depositCreator,
+    depositCreatorAuth,
+    [signatureBuffer],
+    depositOfferOwnerAuth,
+    memo,
+    new BN(0),
+    amountToLock,
+    1,
+    [rewardsOwnerBuffer],
+    1
+  )
+
+  // Create the hash from the tx
+  const txbuff = unsignedTx.toBuffer()
+  const msg: Buffer = Buffer.from(createHash("sha256").update(txbuff).digest())
+
+  // Create the Multisig keychain
+  const addresses = owner.addresses.map((a) => bintools.parseAddress(a, "P"))
+  const outputOwners = new OutputOwners(
+    addresses,
+    new BN(owner.locktime),
+    owner.threshold
+  )
+
+  const numAddresses =
+    depositOfferOwnerAuth.length > 0
+      ? depositOfferOwnerAuth.at(depositOfferOwnerAuth.length - 1)[0]
+      : 0
+
+  const msKeyChain = new MultisigKeyChain(
+    avalanche.getHRP(),
+    PChainAlias,
+    msg,
+    PlatformVMConstants.SECPMULTISIGCREDENTIAL,
+    unsignedTx.getTransaction().getOutputOwners(),
+    new Map([[msigAliasBuffer.toString("hex"), outputOwners]])
+  )
+
+  for (const address of pAddresses) {
+    // We need the keychain for signing
+    const keyPair = pKeychain.getKey(address)
+    // The signature
+    const signature = keyPair.sign(msg)
+    msKeyChain.addKey(new MultisigKeyPair(msKeyChain, address, signature))
+  }
+
+  // Add owner signatures to the multisig keychain
+  const sigs = (unsignedTx.getTransaction() as DepositTx).getOwnerSignatures()
+  sigs.forEach((v) => {
+    msKeyChain.addKey(new MultisigKeyPair(msKeyChain, v[0], v[1]))
+  })
+
+  // Create signature indices (throws if not able to do so)
+  msKeyChain.buildSignatureIndices()
+
+  // Sign the transaction with msig keychain and issue
+  const tx = unsignedTx.sign(msKeyChain)
+  const txid = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/buildDepositTx-v1-SsigDepositor.ts
+++ b/examples/platformvm/buildDepositTx-v1-SsigDepositor.ts
@@ -1,0 +1,92 @@
+import { Avalanche, BinTools, Buffer } from "caminojs/index"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  UnsignedTx,
+  Tx
+} from "caminojs/apis/platformvm"
+import { OutputOwners } from "caminojs/common/output"
+import { PrivateKeyPrefix, DefaultLocalGenesisPrivateKey } from "caminojs/utils"
+import { ExamplesConfig } from "../common/examplesConfig"
+import BN from "bn.js"
+import createHash from "create-hash"
+import { SignerKeyPair } from "caminojs/common"
+
+const config: ExamplesConfig = require("../common/examplesConfig.json")
+const avalanche: Avalanche = new Avalanche(
+  config.host,
+  config.port,
+  config.protocol,
+  config.networkID
+)
+const ownerPrivKey: string =
+  "PrivateKey-Ge71NJhUY3TjZ9dLohijSnNq46QxobjqxHGMUDAPoVsNFA93w"
+
+const bintools: BinTools = BinTools.getInstance()
+const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+let pchain: PlatformVMAPI
+let pKeychain: KeyChain
+let pAddresses: Buffer[]
+let pAddressStrings: string[]
+
+const InitAvalanche = async () => {
+  await avalanche.fetchNetworkSettings()
+  pchain = avalanche.PChain()
+  pKeychain = pchain.keyChain()
+  pKeychain.importKey(privKey) // P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68
+  pAddresses = pchain.keyChain().getAddresses()
+  pAddressStrings = pchain.keyChain().getAddressStrings()
+}
+
+const main = async (): Promise<any> => {
+  await InitAvalanche()
+  const depositOwner = "P-kopernikus13kyf72ftu4l77kss7xm0kshm0au29s48zjaygq"
+  const amountToLock = new BN(1000000)
+  const depositOfferID = "2kRcnwGMJGZPQGKtq2ayBTsxjUaGdDSRphVfHV9KLHvuWhykgR"
+  const depositDuration = 110
+  const memo: Buffer = Buffer.from(
+    "DepositTx v1 with singlesig deposit offer owner"
+  )
+
+  const depositCreator = pAddresses[0]
+  const rewardsOwner = new OutputOwners([depositCreator], undefined, 1)
+  const depositCreatorAuth: [number, string | Buffer][] = [[0, depositCreator]]
+
+  const depositOfferOwnerAuth: [number, string | Buffer][] = [[0, depositOwner]]
+
+  // hash concatenated bytes of offer id and deposit owner address
+  const msgHashed: Buffer = Buffer.from(
+    createHash("sha256")
+      .update(
+        Buffer.concat([bintools.cb58Decode(depositOfferID), depositCreator])
+      )
+      .digest()
+  )
+
+  const keypair: SignerKeyPair = pKeychain.importKey(ownerPrivKey)
+  // sign the hash
+  const signatureBuffer: Buffer = keypair.sign(msgHashed)
+
+  const unsignedTx: UnsignedTx = await pchain.buildDepositTx(
+    1,
+    undefined,
+    pAddressStrings,
+    pAddressStrings,
+    depositOfferID,
+    depositDuration,
+    rewardsOwner,
+    depositCreator,
+    depositCreatorAuth,
+    [signatureBuffer],
+    depositOfferOwnerAuth,
+    memo,
+    new BN(0),
+    amountToLock
+  )
+
+  const tx: Tx = unsignedTx.sign(pKeychain)
+  const txid: string = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/src/apis/platformvm/adddepositoffertx.ts
+++ b/src/apis/platformvm/adddepositoffertx.ts
@@ -121,10 +121,6 @@ export class Offer {
     }
   }
 
-  getMemo(): Buffer {
-    return this.memo
-  }
-
   deserialize(fields: object, encoding: SerializedEncoding = "hex"): this {
     const upgradeVersion = serialization.decoder(
       fields["upgradeVersion"],
@@ -424,6 +420,55 @@ export class Offer {
       )
     }
     return Buffer.concat(buffer, bsize)
+  }
+
+  getUpgradeVersionID(): UpgradeVersionID {
+    return this.upgradeVersionID
+  }
+  getInterestRateNominator(): Buffer {
+    return this.interestRateNominator
+  }
+  getStart(): Buffer {
+    return this.start
+  }
+  getEnd(): Buffer {
+    return this.end
+  }
+  getMinAmount(): Buffer {
+    return this.minAmount
+  }
+  getTotalMaxAmount(): Buffer {
+    return this.totalMaxAmount
+  }
+  getDepositedAmount(): Buffer {
+    return this.depositedAmount
+  }
+  getMinDuration(): Buffer {
+    return this.minDuration
+  }
+  getMaxDuration(): Buffer {
+    return this.maxDuration
+  }
+  getUnlockPeriodDuration(): Buffer {
+    return this.unlockPeriodDuration
+  }
+  getNoRewardsPeriodDuration(): Buffer {
+    return this.noRewardsPeriodDuration
+  }
+  getMemo(): Buffer {
+    return this.memo
+  }
+  getFlags(): Buffer {
+    return this.flags
+  }
+  getTotalMaxRewardAmount(): Buffer {
+    return this.totalMaxRewardAmount
+  }
+  getRewardedAmount(): Buffer {
+    return this.rewardedAmount
+  }
+  getOwnerAddress(): Buffer {
+    return this.ownerAddress
   }
 }
 

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -2552,7 +2552,9 @@ export class PlatformVMAPI extends JRPCAPI {
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
     amountToLock: BN,
-    changeThreshold: number = 1
+    changeThreshold: number = 1,
+    to: Buffer[] = [],
+    toThreshold: number = 0
   ): Promise<UnsignedTx> => {
     const caller = "buildDepositTx"
 
@@ -2618,7 +2620,9 @@ export class PlatformVMAPI extends JRPCAPI {
       memo,
       asOf,
       amountToLock,
-      changeThreshold
+      changeThreshold,
+      to,
+      toThreshold
     )
 
     if (!(await this.checkGooseEgg(builtUnsignedTx, this.getCreationTxFee()))) {

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1326,7 +1326,9 @@ export class Builder {
     memo: Buffer = undefined,
     asOf: BN = zero,
     amountToLock: BN,
-    changeThreshold: number = 1
+    changeThreshold: number = 1,
+    to: Buffer[] = [],
+    toThreshold: number = 0
   ): Promise<UnsignedTx> => {
     let ins: TransferableInput[] = []
     let outs: TransferableOutput[] = []
@@ -1334,8 +1336,8 @@ export class Builder {
 
     if (this._feeCheck(fee, feeAssetID)) {
       const aad: AssetAmountDestination = new AssetAmountDestination(
-        [],
-        0,
+        to,
+        toThreshold,
         fromSigner.from,
         fromSigner.signer,
         changeAddresses,

--- a/src/apis/platformvm/depositTx.ts
+++ b/src/apis/platformvm/depositTx.ts
@@ -148,9 +148,11 @@ export class DepositTx extends BaseTx {
   }
 
   addOwnerAuth(auth: [number, Buffer][], sigs: Buffer[]): void {
-    auth.forEach((p) =>
-      this.addSignatureIdx(1, this.ownerAuth, p[0], undefined)
-    )
+    auth.forEach((p) => {
+      const pseudoAddr = Buffer.alloc(20)
+      pseudoAddr.writeUIntBE(auth.indexOf(p) + 1, 16, 4)
+      this.addSignatureIdx(1, this.ownerAuth, p[0], pseudoAddr)
+    })
     this.ownerSignatures = sigs
   }
 


### PR DESCRIPTION
## Why this should be merged
When building a deposit tx for a restricted offer from an msig wallet, a certain logic with pseudo addresses is incorporated 
(see https://github.com/chain4travel/caminojs/blob/dev/src/apis/platformvm/builder.ts#L1387) to facilitate the processing of signatures in case of a multisig keychain.
However, when building the signature indices in the case of the deposit offer owner, the key cannot be found unless you add it to the keychain with the same pseudo address. See https://github.com/chain4travel/caminojs/blob/dev/src/common/multisigkeychain.ts#L250

## How this works
This PR addresses this issue by refactoring `addOwnerAuth` and adding the pseudo addresses in the indices. Thus, when adding the owner signatures to the ms keychain using the `getOwnerSignatures`, there will be a match between the pseudo addresses set in the Output Owners  via the builder and the ones added via `addOwnerAuth`.

## How this was tested
See new examples.