### PR TITLE
[PVM] Add unlockableAmount field to APIDeposit interface and getDeposit request

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -655,6 +655,7 @@ export class PlatformVMAPI extends JRPCAPI {
           depositTxID: deposit.depositTxID,
           depositOfferID: deposit.depositOfferID,
           unlockedAmount: new BN(deposit.unlockedAmount),
+          unlockableAmount: new BN(deposit.unlockableAmount),
           claimedRewardAmount: new BN(deposit.claimedRewardAmount),
           start: new BN(deposit.start),
           duration: deposit.duration,

--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -292,6 +292,7 @@ export interface APIDeposit {
   depositTxID: string
   depositOfferID: string
   unlockedAmount: BN
+  unlockableAmount: BN
   claimedRewardAmount: BN
   start: BN
   duration: number

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -2685,6 +2685,7 @@ describe("PlatformVMAPI", (): void => {
             start: "5",
             duration: 6,
             amount: "7",
+            unlockableAmount: "8",
             rewardOwner: {
               locktime: 0,
               threshold: 1,
@@ -2726,6 +2727,7 @@ describe("PlatformVMAPI", (): void => {
     expect(response.deposits[0].start).toStrictEqual(new BN("5"))
     expect(response.deposits[0].duration).toBe(6)
     expect(response.deposits[0].amount).toStrictEqual(new BN("7"))
+    expect(response.deposits[0].unlockableAmount).toStrictEqual(new BN("8"))
     expect(response.deposits[0].rewardOwner.locktime).toStrictEqual(new BN("0"))
     expect(response.deposits[0].rewardOwner.threshold).toBe(1)
     expect(response.deposits[0].rewardOwner.addresses).toStrictEqual([addrA])


### PR DESCRIPTION
## Why this should be merged
The introduction of the unlockableAmount field in both the APIDeposit interface and the getDeposit request marks a significant improvement in our API's functionality.

## How this works
**Addition of the `unlockableAmount` Field:** The unlockableAmount field has been added to the APIDeposit interface. This field represents the amount from a deposit that is available for unlocking

## How this was tested