### PR TITLE
Fix spend logic for unlock deposit amount

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -2586,7 +2586,7 @@ export class PlatformVMAPI extends JRPCAPI {
     })
 
     if (depositOfferOwnerAuth.length !== depositOfferOwnerSigs.length) {
-      throw new Error("OwnerAuth length must mathch OwnerSigs length")
+      throw new Error("OwnerAuth length must match OwnerSigs length")
     }
 
     const o_auth: [number, Buffer][] = []
@@ -2641,17 +2641,18 @@ export class PlatformVMAPI extends JRPCAPI {
    * @param changeAddresses The addresses that can spend the change remaining from the spent UTXOs.
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
+   * @param amountToUnlock The amount of tokens to unlock from the deposit
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
    *
    * @returns An unsigned transaction created from the passed in parameters.
    */
   buildUnlockDepositTx = async (
     utxoset: UTXOSet,
-    fromAddresses: string[],
+    fromAddresses: FromType,
     changeAddresses: string[] = undefined,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
-    amountToLock: BN,
+    amountToUnlock: BN,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     const caller = "buildUnlockDepositTx"
@@ -2680,6 +2681,7 @@ export class PlatformVMAPI extends JRPCAPI {
       avaxAssetID,
       memo,
       asOf,
+      amountToUnlock,
       changeThreshold
     )
 

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1415,6 +1415,7 @@ export class Builder {
    * @param feeAssetID Optional. The assetID of the fees being burned
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
+   * @param amountToUnlock The amount of tokens to unlock
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
    *
    * @returns An unsigned UnlockDepositTx created from the passed in parameters.
@@ -1428,6 +1429,7 @@ export class Builder {
     feeAssetID: Buffer = undefined,
     memo: Buffer = undefined,
     asOf: BN = zero,
+    amountToUnlock: BN,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     let ins: TransferableInput[] = []
@@ -1443,7 +1445,7 @@ export class Builder {
         changeThreshold
       )
 
-      aad.addAssetAmount(feeAssetID, zero, fee)
+      aad.addAssetAmount(feeAssetID, amountToUnlock, fee)
 
       const minSpendableErr: Error = await this.spender.getMinimumSpendable(
         aad,


### PR DESCRIPTION
This PR changes the signature of api buildUnlockDepositTx by converting fromAddresses to commonly used `FromType` and adds the argument `amountToUnlock` in the builder function to consider it when constructing in/output utxos by calling the node spend logic.