### PR TITLE
Remove "to" argument (set to empty Buffer) in buildCaminoAddValidatorTx

### DIFF
--- a/e2e_tests/camino/pchain_nomock.test.ts
+++ b/e2e_tests/camino/pchain_nomock.test.ts
@@ -160,7 +160,6 @@ describe("Camino-PChain-Add-Validator", (): void => {
             dummyUtxoSet,
             [P(addrAdminString)],
             [P(addrAdminString)],
-            [P(addrAdminString)],
             adminNodeId,
             {
               address: P(addrAdminString),
@@ -189,7 +188,6 @@ describe("Camino-PChain-Add-Validator", (): void => {
           const stakeAmount: any = await pChain.getMinStake()
           const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             dummyUtxoSet,
-            [P(addrAdminString)],
             [P(addrAdminString)],
             [P(addrAdminString)],
             node6Id,
@@ -263,7 +261,6 @@ describe("Camino-PChain-Add-Validator", (): void => {
           const stakeAmount: any = await pChain.getMinStake()
           const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             dummyUtxoSet,
-            [P(addrBString)], // "X-kopernikus1s93gzmzuvv7gz8q4l83xccrdchh8mtm3xm5s2g"
             [P(addrBString)],
             [P(addrBString)],
             node6Id,
@@ -1301,7 +1298,6 @@ describe("Camino-PChain-Multisig", (): void => {
 
           const unsignedTx: UnsignedTx = await pChain.buildCaminoAddValidatorTx(
             utxoSet,
-            [P(multiSigAliasAddr)],
             [[P(multiSigAliasAddr)], [pAddressStrings[5]]],
             [P(multiSigAliasAddr)],
             node7Id, // the node where the alias is registered

--- a/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig-from-separate-signatures.ts
+++ b/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig-from-separate-signatures.ts
@@ -198,7 +198,6 @@ const sendAddValidatorTx = async (): Promise<any> => {
 
     const unsignedTx: UnsignedTx = await pchain.buildCaminoAddValidatorTx(
       utxoSet,
-      [msigAlias],
       [[msigAlias], pAddressStrings],
       [msigAlias],
       nodeID,

--- a/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig.ts
+++ b/examples/platformvm/buildRegisterNodeTx-buildAddValidatorTx-P-Chain-Msig.ts
@@ -137,7 +137,6 @@ const sendAddValidatorTx = async (): Promise<any> => {
 
   const unsignedTx: UnsignedTx = await pchain.buildCaminoAddValidatorTx(
     utxoSet,
-    [msigAlias],
     [[msigAlias], pAddressStrings],
     [msigAlias],
     nodeID,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/caminojs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Camino Platform JS Library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -2307,7 +2307,6 @@ export class PlatformVMAPI extends JRPCAPI {
    */
   buildCaminoAddValidatorTx = async (
     utxoset: UTXOSet,
-    toAddresses: string[],
     fromAddresses: FromType,
     changeAddresses: string[],
     nodeID: string,
@@ -2324,8 +2323,6 @@ export class PlatformVMAPI extends JRPCAPI {
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     const caller = "buildCaminoAddValidatorTx"
-
-    const to: Buffer[] = this._cleanAddressArrayBuffer(toAddresses, caller)
 
     const fromSigner = this._parseFromSigner(fromAddresses, caller)
 
@@ -2372,7 +2369,6 @@ export class PlatformVMAPI extends JRPCAPI {
     ).buildCaminoAddValidatorTx(
       this.core.getNetworkID(),
       bintools.cb58Decode(this.blockchainID),
-      to,
       fromSigner,
       change,
       NodeIDStringToBuffer(nodeID),

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1035,7 +1035,7 @@ export class Builder {
   buildCaminoAddValidatorTx = async (
     networkID: number = DefaultNetworkID,
     blockchainID: Buffer,
-    to: Buffer[],
+    to: Buffer[] = undefined,
     fromSigner: FromSigner,
     change: Buffer[],
     nodeID: Buffer,
@@ -1064,7 +1064,7 @@ export class Builder {
     }
 
     const aad: AssetAmountDestination = new AssetAmountDestination(
-      to,
+      [],
       toThreshold,
       fromSigner.from,
       fromSigner.signer,

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1035,7 +1035,6 @@ export class Builder {
   buildCaminoAddValidatorTx = async (
     networkID: number = DefaultNetworkID,
     blockchainID: Buffer,
-    to: Buffer[] = undefined,
     fromSigner: FromSigner,
     change: Buffer[],
     nodeID: Buffer,


### PR DESCRIPTION
## Why this should be merged
Ins/outs creation on node api now prohibits non-nil "to" and bond-locking args at the same time
according to node api, it will use nil to, if request "to" has zero addresses in it or empty

## How this works
removes "to" argument form buildCaminoAddValidatorTx and sends an empty field to AssetAmountDestination
## How this was tested
-