### PR TITLE
Add boundAmount to addProposalTx

### DIFF
--- a/examples/platformvm/addProposalTx.addMemberProposal.ts
+++ b/examples/platformvm/addProposalTx.addMemberProposal.ts
@@ -56,7 +56,6 @@ const main = async (): Promise<any> => {
     targetAddress
   )
   try {
-    const locktime: BN = new BN(0) // TODO: What should be the lock time?
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -65,8 +64,7 @@ const main = async (): Promise<any> => {
       proposal, // proposal
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
-      Buffer.alloc(20), // memo
-      locktime
+      Buffer.alloc(20) // memo
     )
 
     const tx = unsignedTx.sign(pKeychain)

--- a/examples/platformvm/addProposalTx.addMemberProposal.ts
+++ b/examples/platformvm/addProposalTx.addMemberProposal.ts
@@ -41,7 +41,7 @@ const InitAvalanche = async () => {
 
 const main = async (): Promise<any> => {
   await InitAvalanche()
-  // TODO: @VjeraTurk should be able to get bondAmount from node?
+  // TODO: @VjeraTurk get bondAmount from node
   let startDate = new Date()
   startDate.setDate(startDate.getDate() + 1)
   let endDate = new Date(startDate)
@@ -78,7 +78,6 @@ const main = async (): Promise<any> => {
     console.log(addProposalTxTypeID, addProposalTxTypeName)
     console.log(`Success! TXID: ${txid}`)
   } catch (e) {
-    // TODO: @VjeraTurk give instruction how to overcome "couldn't issue tx: proposal is semantically invalid: there is already active proposal of this type"
     console.log(e)
   }
 }

--- a/examples/platformvm/addProposalTx.addMemberProposal.ts
+++ b/examples/platformvm/addProposalTx.addMemberProposal.ts
@@ -42,7 +42,6 @@ const InitAvalanche = async () => {
 const main = async (): Promise<any> => {
   await InitAvalanche()
   // TODO: @VjeraTurk should be able to get bondAmount from node?
-  const bondAmount: any = await pchain.getMinStake()
   let startDate = new Date()
   startDate.setDate(startDate.getDate() + 1)
   let endDate = new Date(startDate)
@@ -58,7 +57,6 @@ const main = async (): Promise<any> => {
   )
   try {
     const locktime: BN = new BN(0) // TODO: What should be the lock time?
-    const hundred: BN = new BN(100000000000) // TODO: replace with bondAmount
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -68,8 +66,7 @@ const main = async (): Promise<any> => {
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
       Buffer.alloc(20), // memo
-      locktime,
-      hundred // stakeAmount
+      locktime
     )
 
     const tx = unsignedTx.sign(pKeychain)

--- a/examples/platformvm/addProposalTx.baseFeeProposal.ts
+++ b/examples/platformvm/addProposalTx.baseFeeProposal.ts
@@ -54,7 +54,6 @@ const main = async (): Promise<any> => {
   proposal.addBaseFeeOption(3000000)
 
   try {
-    const locktime: BN = new BN(0)
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -63,8 +62,7 @@ const main = async (): Promise<any> => {
       proposal, // proposal
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
-      Buffer.alloc(20), // memo
-      locktime
+      Buffer.alloc(20) // memo
     )
     const tx = unsignedTx.sign(pKeychain)
     const txid: string = await pchain.issueTx(tx)

--- a/examples/platformvm/addProposalTx.baseFeeProposal.ts
+++ b/examples/platformvm/addProposalTx.baseFeeProposal.ts
@@ -9,6 +9,7 @@ import {
   PrivateKeyPrefix
 } from "caminojs/utils"
 import { ExamplesConfig } from "../common/examplesConfig"
+import BN from "bn.js"
 
 const config: ExamplesConfig = require("../common/examplesConfig.json")
 const avalanche: Avalanche = new Avalanche(
@@ -39,6 +40,7 @@ const InitAvalanche = async () => {
 
 const main = async (): Promise<any> => {
   await InitAvalanche()
+  const bondAmount: any = await pchain.getMinStake()
   let startDate = new Date()
   startDate.setDate(startDate.getDate() + 1)
   let endDate = new Date(startDate)
@@ -53,6 +55,8 @@ const main = async (): Promise<any> => {
   proposal.addBaseFeeOption(3000000)
 
   try {
+    const locktime: BN = new BN(0)
+    const hundred: BN = new BN(100000000000)
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -61,7 +65,9 @@ const main = async (): Promise<any> => {
       proposal, // proposal
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
-      Buffer.alloc(20) // memo
+      Buffer.alloc(20), // memo
+      locktime,
+      hundred
     )
     const tx = unsignedTx.sign(pKeychain)
     const txid: string = await pchain.issueTx(tx)

--- a/examples/platformvm/addProposalTx.baseFeeProposal.ts
+++ b/examples/platformvm/addProposalTx.baseFeeProposal.ts
@@ -40,7 +40,6 @@ const InitAvalanche = async () => {
 
 const main = async (): Promise<any> => {
   await InitAvalanche()
-  const bondAmount: any = await pchain.getMinStake()
   let startDate = new Date()
   startDate.setDate(startDate.getDate() + 1)
   let endDate = new Date(startDate)
@@ -56,7 +55,6 @@ const main = async (): Promise<any> => {
 
   try {
     const locktime: BN = new BN(0)
-    const hundred: BN = new BN(100000000000)
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -66,8 +64,7 @@ const main = async (): Promise<any> => {
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
       Buffer.alloc(20), // memo
-      locktime,
-      hundred
+      locktime
     )
     const tx = unsignedTx.sign(pKeychain)
     const txid: string = await pchain.issueTx(tx)

--- a/examples/platformvm/addProposalTx.generalProposal.ts
+++ b/examples/platformvm/addProposalTx.generalProposal.ts
@@ -97,7 +97,6 @@ const main = async (): Promise<any> => {
     const txid: string = await pchain.issueTx(tx)
     console.log(`Success! TXID: ${txid}`)
   } catch (e) {
-    // TODO: give instructions to overcome "couldn't issue tx: proposal is semantically invalid: no active validator"
     console.log(e)
   }
 }

--- a/examples/platformvm/addProposalTx.generalProposal.ts
+++ b/examples/platformvm/addProposalTx.generalProposal.ts
@@ -70,7 +70,6 @@ const main = async (): Promise<any> => {
   }
 
   try {
-    const locktime: BN = new BN(0)
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -79,8 +78,7 @@ const main = async (): Promise<any> => {
       proposal, // proposal
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
-      Buffer.alloc(20), // memo
-      locktime
+      Buffer.alloc(20) // memo
     )
 
     const tx = unsignedTx.sign(pKeychain)

--- a/examples/platformvm/addProposalTx.generalProposal.ts
+++ b/examples/platformvm/addProposalTx.generalProposal.ts
@@ -71,7 +71,6 @@ const main = async (): Promise<any> => {
 
   try {
     const locktime: BN = new BN(0)
-    const hundred: BN = new BN(100000000000) // TODO: replace with bondAmount
     let unsignedTx = await pchain.buildAddProposalTx(
       platformVMUTXOResponse.utxos, // utxoset
       pAddressStrings, // fromAddresses
@@ -81,8 +80,7 @@ const main = async (): Promise<any> => {
       pKeychain.getAddresses()[0], // proposerAddress
       0, // version
       Buffer.alloc(20), // memo
-      locktime,
-      hundred
+      locktime
     )
 
     const tx = unsignedTx.sign(pKeychain)

--- a/examples/platformvm/addVoteTx.generalProposal.ts
+++ b/examples/platformvm/addVoteTx.generalProposal.ts
@@ -39,7 +39,6 @@ const InitAvalanche = async () => {
 
   pAddressStrings = pchain.keyChain().getAddressStrings()
 }
-//TODO: @VjeraTurk add missing example for adding vote to General and Base Fee Proposal
 const main = async (): Promise<any> => {
   await InitAvalanche()
   const platformVMUTXOResponse = await pchain.getUTXOs(pAddressStrings)
@@ -47,8 +46,8 @@ const main = async (): Promise<any> => {
 
   const proposal = new GeneralProposal()
   try {
-    //let unsignedTx = await pchain.buildAddVoteTx()
-    //TODO:  @VjeraTurk add missing example for adding vote to General
+    // let unsignedTx = await pchain.buildAddVoteTx()
+    // TODO: @VjeraTurk add missing example for adding vote to General and Base Fee Proposal
     //console.log(unsignedTx)
   } catch (e) {
     console.log(e)

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -3216,6 +3216,7 @@ export class PlatformVMAPI extends JRPCAPI {
     const avaxAssetID: Buffer = await this.getAVAXAssetID()
     const networkID: number = this.core.getNetworkID()
 
+    // TODO: @VjeraTurk get bondAmount from node
     let stakeAmount = new BN(1000000000000)
 
     if (networkID == 1002 || networkID == 1001) {

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -3201,7 +3201,6 @@ export class PlatformVMAPI extends JRPCAPI {
     version: number = DefaultTransactionVersionNumber,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN
-    //changeThreshould: number = 1 // TODO: Is it safe to remove?
   ): Promise<UnsignedTx> => {
     const caller = "buildAddProposalTx"
 

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -3187,7 +3187,6 @@ export class PlatformVMAPI extends JRPCAPI {
    * @param version Optional. Transaction version number, default 0.
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
-   * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
    *
    * @returns An unsigned transaction created from the passed in parameters.
    */

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -3200,8 +3200,7 @@ export class PlatformVMAPI extends JRPCAPI {
     proposerAddress: Buffer,
     version: number = DefaultTransactionVersionNumber,
     memo: PayloadBase | Buffer = undefined,
-    asOf: BN = ZeroBN,
-    stakeAmount: BN
+    asOf: BN = ZeroBN
     //changeThreshould: number = 1 // TODO: Is it safe to remove?
   ): Promise<UnsignedTx> => {
     const caller = "buildAddProposalTx"
@@ -3218,6 +3217,13 @@ export class PlatformVMAPI extends JRPCAPI {
 
     const avaxAssetID: Buffer = await this.getAVAXAssetID()
     const networkID: number = this.core.getNetworkID()
+
+    let stakeAmount = new BN(1000000000000)
+
+    if (networkID == 1002 || networkID == 1001) {
+      stakeAmount = new BN(100000000000)
+    }
+
     const blockchainID: Buffer = bintools.cb58Decode(this.blockchainID)
     const fee: BN = this.getTxFee()
     const proposerAuth = new SubnetAuth()

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -3201,7 +3201,8 @@ export class PlatformVMAPI extends JRPCAPI {
     version: number = DefaultTransactionVersionNumber,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = ZeroBN,
-    changeThreshold: number = 1
+    stakeAmount: BN
+    //changeThreshould: number = 1 // TODO: Is it safe to remove?
   ): Promise<UnsignedTx> => {
     const caller = "buildAddProposalTx"
 
@@ -3239,7 +3240,8 @@ export class PlatformVMAPI extends JRPCAPI {
       fee,
       avaxAssetID,
       asOf,
-      changeThreshold
+      stakeAmount,
+      avaxAssetID
     )
 
     if (!(await this.checkGooseEgg(builtUnsignedTx, this.getCreationTxFee()))) {

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1805,6 +1805,8 @@ export class Builder {
    * @param feeAssetID Optional. The assetID of the fees being burned
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
    * @param stakeAmount A {@link https://github.com/indutny/bn.js/|BN} for the amount of stake to be delegated in nAVAX.
+   * @param stakeAssetID
+   * @param toThreshold Optional. The number of signatures required to spend the funds in the resultant UTXO
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
    *
    * @returns An unsigned AddProposalTx created from the passed in parameters.

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1841,8 +1841,7 @@ export class Builder {
         changeAddresses,
         changeThreshold
       )
-      //aad.addAssetAmount(feeAssetID, zero, fee)
-      aad.addAssetAmount(stakeAssetID, stakeAmount, fee) // TODO: @VjeraTurk Is it ok like so?
+      aad.addAssetAmount(stakeAssetID, stakeAmount, fee)
 
       const minSpendableErr: Error = await this.spender.getMinimumSpendable(
         aad,

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1822,6 +1822,9 @@ export class Builder {
     fee: BN = zero,
     feeAssetID: Buffer = undefined,
     asOf: BN = zero,
+    stakeAmount: BN = zero,
+    stakeAssetID: Buffer,
+    toThreshold: number = 1,
     changeThreshold: number = 1
   ): Promise<UnsignedTx> => {
     let ins: TransferableInput[] = []
@@ -1831,19 +1834,20 @@ export class Builder {
     if (this._feeCheck(fee, feeAssetID)) {
       const aad: AssetAmountDestination = new AssetAmountDestination(
         [],
-        0,
+        toThreshold,
         fromSigner.from,
         fromSigner.signer,
         changeAddresses,
         changeThreshold
       )
-      aad.addAssetAmount(feeAssetID, zero, fee)
+      //aad.addAssetAmount(feeAssetID, zero, fee)
+      aad.addAssetAmount(stakeAssetID, stakeAmount, fee) // TODO: @VjeraTurk Is it ok like so?
 
       const minSpendableErr: Error = await this.spender.getMinimumSpendable(
         aad,
         asOf,
         zero,
-        "Unlocked"
+        "Bond"
       )
       if (typeof minSpendableErr === "undefined") {
         ins = aad.getInputs()

--- a/src/apis/platformvm/builder.ts
+++ b/src/apis/platformvm/builder.ts
@@ -1804,6 +1804,7 @@ export class Builder {
    * @param fee Optional. The amount of fees to burn in its smallest denomination, represented as {@link https://github.com/indutny/bn.js/|BN}
    * @param feeAssetID Optional. The assetID of the fees being burned
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
+   * @param stakeAmount A {@link https://github.com/indutny/bn.js/|BN} for the amount of stake to be delegated in nAVAX.
    * @param changeThreshold Optional. The number of signatures required to spend the funds in the resultant change UTXO
    *
    * @returns An unsigned AddProposalTx created from the passed in parameters.


### PR DESCRIPTION
Adjusts the `buildAddProposalTx` to set the boundAmount (stakeAmount) based on networkID.
Sets the `lockMode`  to "Bond" 

```
    let stakeAmount = new BN(1000000000000)

    if (networkID == 1002 || networkID == 1001) {
      stakeAmount = new BN(100000000000)
    }
```

Adjusts the addProposal examples