### PR TITLE
remove -rc and deprecated tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/caminojs",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0",
   "description": "Camino Platform JS Library",
   "main": "dist/index.js",
   "scripts": {

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -1608,7 +1608,8 @@ describe("PlatformVMAPI", (): void => {
 
       serialzeit(tx1, "AddDelegatorTx")
     })
-
+    /*
+   TODO: @VjeraTurk Change to buildAddCaminoValidatorTX
     test("buildAddValidatorTx sort StakeableLockOuts 1", async (): Promise<void> => {
       // two UTXO. The 1st has a lesser stakeablelocktime and a greater amount of AVAX. The 2nd has a greater stakeablelocktime and a lesser amount of AVAX.
       // We expect this test to only consume the 2nd UTXO since it has the greater locktime.
@@ -2145,7 +2146,7 @@ describe("PlatformVMAPI", (): void => {
         stakeableLockOut2.getStakeableLocktime().toString()
       )
     })
-
+*/
     test("buildAddValidatorTx 1", async (): Promise<void> => {
       const addrbuff1 = addrs1.map((a) => platformvm.parseAddress(a))
       const addrbuff2 = addrs2.map((a) => platformvm.parseAddress(a))


### PR DESCRIPTION
If I remember correctly, there was a suggestion for the next release to not be -rc 
Removed the deprecated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the project version from a release candidate to a stable version (1.3.0).
parameters for existing methods.
  
- **Bug Fixes**
	- No bug fixes were included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->