### PR TITLE
feat(platformvm): Add UnlockDepositTx type to transaction selector

### DIFF
--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -35,6 +35,7 @@ import {
   AddValidatorTx,
   CaminoAddValidatorTx
 } from "./validationtx"
+import { UnlockDepositTx } from "./unlockdeposittx"
 
 /**
  * @ignore
@@ -73,6 +74,8 @@ export const SelectTxClass = (txtype: number, ...args: any[]): BaseTx => {
     return new AddressStateTx(...args)
   } else if (txtype === PlatformVMConstants.CLAIMTX) {
     return new ClaimTx(...args)
+  } else if (txtype === PlatformVMConstants.UNLOCKDEPOSITTX) {
+    return new UnlockDepositTx(...args)
   } else if (txtype === PlatformVMConstants.MULTISIGALIASTX) {
     return new MultisigAliasTx(...args)
   } else if (txtype === PlatformVMConstants.ADDDEPOSITOFFERTX) {


### PR DESCRIPTION
## Add UnlockDepositTx to Transaction Selector

This PR adds support for properly deserializing UnlockDepositTx transactions 
by including them in the SelectTxClass function. Previously, casting pending tx would 
throw a "TransactionError: Error - SelectTxClass: unknown txtype" when 
attempting to deserialize pending unsigned transactions of this type.

### Changes
- Added a case for PlatformVMConstants.UNLOCKDEPOSITTX in the SelectTxClass function