### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/caminojs",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Camino Platform JS Library",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the package version in package.json to 1.4.0, following the new feature that was previously merged.